### PR TITLE
Refactor watch interval setting and worker update

### DIFF
--- a/app/src/main/java/eu/darken/apl/watch/ui/settings/WatchSettingsFragment.kt
+++ b/app/src/main/java/eu/darken/apl/watch/ui/settings/WatchSettingsFragment.kt
@@ -18,7 +18,7 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class WatchSettingsFragment : PreferenceFragment2() {
 
-    private val vdc: WatchSettingsViewModel by viewModels()
+    private val vm: WatchSettingsViewModel by viewModels()
 
     @Inject lateinit var watchSettings: WatchSettings
 
@@ -60,12 +60,11 @@ class WatchSettingsFragment : PreferenceFragment2() {
                     setTitle(R.string.watch_settings_monitor_interval_title)
                     setView(dialogLayout.root)
                     setPositiveButton(R.string.common_save_action) { _, _ ->
-                        settings.watchMonitorInterval.valueBlocking =
-                            Duration.ofMinutes(dialogLayout.slider.value.toLong())
+                        vm.updateWatchInterval(Duration.ofMinutes(dialogLayout.slider.value.toLong()))
                     }
                     setNegativeButton(R.string.common_cancel_action) { _, _ -> }
                     setNeutralButton(R.string.common_reset_action) { _, _ ->
-                        settings.watchMonitorInterval.valueBlocking = WatchSettings.DEFAULT_CHECK_INTERVAL
+                        vm.resetWatchInterval()
                     }
                 }.show()
                 true

--- a/app/src/main/java/eu/darken/apl/watch/ui/settings/WatchSettingsViewModel.kt
+++ b/app/src/main/java/eu/darken/apl/watch/ui/settings/WatchSettingsViewModel.kt
@@ -1,17 +1,34 @@
 package eu.darken.apl.watch.ui.settings
 
-import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.apl.common.coroutine.DispatcherProvider
+import eu.darken.apl.common.datastore.value
+import eu.darken.apl.common.debug.logging.log
 import eu.darken.apl.common.debug.logging.logTag
 import eu.darken.apl.common.uix.ViewModel3
+import eu.darken.apl.watch.core.WatchSettings
+import eu.darken.apl.watch.core.alerts.WatchWorkerHelper
+import java.time.Duration
 import javax.inject.Inject
 
 @HiltViewModel
 class WatchSettingsViewModel @Inject constructor(
-    private val handle: SavedStateHandle,
-    private val dispatcherProvider: DispatcherProvider,
+    dispatcherProvider: DispatcherProvider,
+    private val settings: WatchSettings,
+    private val watchWorkerHelper: WatchWorkerHelper,
 ) : ViewModel3(
     dispatcherProvider,
     tag = logTag("Settings", "Watch", "VM"),
-)
+) {
+    fun updateWatchInterval(interval: Duration) = launch {
+        log(tag) { "updateWatchInterval($interval)" }
+        settings.watchMonitorInterval.value(interval)
+        watchWorkerHelper.updateWorker()
+    }
+
+    fun resetWatchInterval() = launch {
+        log(tag) { "resetWatchInterval()" }
+        settings.watchMonitorInterval.value(WatchSettings.DEFAULT_CHECK_INTERVAL)
+        watchWorkerHelper.updateWorker()
+    }
+}


### PR DESCRIPTION
This commit moves the logic for updating the watch interval and resetting it to the `WatchSettingsViewModel`. It also ensures the `WatchWorkerHelper` updates the periodic worker when the interval changes.

Key changes:
- Added `updateWatchInterval` and `resetWatchInterval` functions to `WatchSettingsViewModel`.
- `WatchSettingsFragment` now calls these ViewModel functions to update/reset the interval.
- `WatchWorkerHelper.updateWorker()` is now public and called when the interval setting changes.
- `WatchWorkerHelper` now uses `ExistingPeriodicWorkPolicy.UPDATE` to allow interval changes.
- `WatchWorkerHelper` initializes the worker based on the current settings value during init.
- Log tag for `WatchWorkerHelper` changed to "Watch.Worker.Helper".