### PR TITLE
Refactor GitHub Actions workflows

### DIFF
--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -1,0 +1,42 @@
+name: 'Common project setup'
+description: 'Setup the base project'
+runs:
+  using: "composite"
+  steps:
+    - name: Set up JDK 17
+      uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 #v4.7.0
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    - name: Grant execute permission for gradlew
+      shell: bash
+      run: chmod +x gradlew
+
+    - name: Cache Gradle Wrapper
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #v4.2.3
+      with:
+        path: |
+          ~/.gradle/wrapper
+          !~/.gradle/wrapper/dists/**/gradle*.zip
+        key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-wrapper-
+
+    - name: Cache Gradle Dependencies
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #v4.2.3
+      with:
+        path: |
+          ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', 'buildSrc/**/*.kt') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-caches-
+
+    - name: Cache Android Global Build-Cache
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #v4.2.3
+      with:
+        path: |
+          ~/.android/build-cache
+        key: ${{ runner.os }}-android-build-cache-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-android-build-cache-

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -7,44 +7,55 @@ on:
     branches: [ main ]
 
 jobs:
-  test-foss:
-    name: Test FOSS flavor
-    runs-on: ubuntu-latest
-
+  lint-vital:
+    name: Lint vitals
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor: [ Foss,Gplay ]
+        variant: [ Beta,Release ]
+        module: [ app ]
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK
-        uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'adopt'
-          cache: gradle
+      - name: Checkout source code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+      - name: Setup project and build environment
+        uses: ./.github/actions/common-setup
 
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
+      - name: Check for fatal lint issues
+        run: ./gradlew lintVital${{ matrix.flavor }}${{ matrix.variant }}
 
-      - name: Build FOSS variant
-        run: ./gradlew assembleFossDebug
-      - name: Test FOSS variant
-        run: ./gradlew testFossDebugUnitTest
-
-  test-gplay:
-    name: Test Google Play flavor
-    runs-on: ubuntu-latest
-
+  build-modules:
+    name: Build apps
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor: [ Foss,Gplay ]
+        variant: [ Debug ]
+        module: [ app ]
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK
-        uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'adopt'
-          cache: gradle
+      - name: Checkout source code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+      - name: Setup project and build environment
+        uses: ./.github/actions/common-setup
 
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
+      - name: Build modules
+        run: ./gradlew ${{ matrix.module }}:assemble${{ matrix.flavor }}${{ matrix.variant }}
 
-      - name: Build Google Play variant
-        run: ./gradlew assembleGplayDebug
-      - name: Test Google Play variant
-        run: ./gradlew testGplayDebugUnitTest
+  test-modules:
+    name: Unit tests
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [ Debug,Beta,Release ]
+        flavor: [ test,testFoss,testGplay ]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+      - name: Setup project and build environment
+        uses: ./.github/actions/common-setup
+
+      - name: Test modules
+        run: ./gradlew ${{ matrix.flavor }}${{ matrix.variant }}UnitTest

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   validation:
     name: "Validation"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+      - uses: gradle/actions/wrapper-validation@06832c7b30a0129d7fb559bcc6e43d26f6374244 #v4.3.1

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -8,7 +8,9 @@ on:
 jobs:
   release-github:
     name: Create GitHub release
-    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    runs-on: ubuntu-22.04
     environment: foss-production
     steps:
       - name: Decode Keystore
@@ -21,24 +23,21 @@ jobs:
           echo $ENCODED_KEYSTORE | base64 -di > "${TMP_KEYSTORE_FILE_PATH}"
           echo "STORE_PATH=$(echo $TMP_KEYSTORE_FILE_PATH)" >> $GITHUB_ENV
 
-      - name: Checkout
-        uses: actions/checkout@v3
+      - name: Checkout source code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           fetch-depth: 0
 
+      - name: Setup project and build environment
+        uses: ./.github/actions/common-setup
+
       - name: Get the version
         id: tagger
-        uses: jimschubert/query-tag-action@v2
+        uses: jimschubert/query-tag-action@0b288a5fff630fea2e96d61b99047ed823ca19dc #v2.2
         with:
           skip-unshallow: 'true'
           abbrev: false
           commit-ish: HEAD
-
-      - name: Install JDK
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'adopt'
-          java-version: 17
 
       - name: Assemble beta APK
         if: contains(steps.tagger.outputs.tag, '-beta')
@@ -48,7 +47,6 @@ jobs:
           STORE_PASSWORD: ${{ secrets.STORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-          BUGSNAG_API_KEY: ${{ secrets.BUGSNAG_API_KEY }}
 
       - name: Assemble production APK
         if: "!contains(steps.tagger.outputs.tag, '-beta')"
@@ -58,11 +56,10 @@ jobs:
           STORE_PASSWORD: ${{ secrets.STORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-          BUGSNAG_API_KEY: ${{ secrets.BUGSNAG_API_KEY }}
 
       - name: Create pre-release
         if: contains(steps.tagger.outputs.tag, '-beta')
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda #v2.2.1
         with:
           prerelease: true
           tag_name: ${{ steps.tagger.outputs.tag }}
@@ -74,7 +71,7 @@ jobs:
 
       - name: Create release
         if: "!contains(steps.tagger.outputs.tag, '-beta')"
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda #v2.2.1
         with:
           prerelease: false
           tag_name: ${{ steps.tagger.outputs.tag }}


### PR DESCRIPTION
This commit refactors the GitHub Actions workflows to improve maintainability and efficiency.

Key changes:
- Introduced a reusable composite action `common-setup` for shared setup steps like JDK installation, Gradle permissions, and caching.
- Updated `gradle-wrapper-validation.yml`, `release-tag.yml`, and `code-checks.yml` to use `ubuntu-22.04` as the runner.
- Updated various actions to their latest versions (e.g., `actions/checkout`, `gradle/wrapper-validation-action`, `jimschubert/query-tag-action`, `softprops/action-gh-release`, `actions/setup-java`, `actions/cache`).
- Modified `release-tag.yml`:
    - Added `contents: write` permission.
    - Replaced individual JDK setup with the `common-setup` action.
    - Removed `BUGSNAG_API_KEY` from environment variables for build steps.
- Reworked `code-checks.yml`:
    - Replaced separate FOSS and Gplay test jobs with matrix-based jobs for `lint-vital`, `build-modules`, and `test-modules`.
    - `lint-vital` now runs for Foss/Gplay flavors and Beta/Release variants.
    - `build-modules` now builds app modules for Foss/Gplay flavors and Debug variants.
    - `test-modules` now runs unit tests for Debug/Beta/Release variants and test/testFoss/testGplay flavors.
    - Utilizes the `common-setup` action for consistent environment setup.
- The `common-setup` action includes steps for:
    - Setting up JDK 17 (temurin distribution).
    - Granting execute permission for `gradlew`.
    - Caching Gradle Wrapper, Gradle Dependencies, and Android Global Build-Cache.