### PR TITLE
Persist last update timestamp and improve offline check

### DIFF
--- a/app/src/main/java/eu/darken/apl/feeder/core/FeederRepo.kt
+++ b/app/src/main/java/eu/darken/apl/feeder/core/FeederRepo.kt
@@ -1,5 +1,6 @@
 package eu.darken.apl.feeder.core
 
+import eu.darken.apl.common.datastore.value
 import eu.darken.apl.common.debug.logging.Logging.Priority.INFO
 import eu.darken.apl.common.debug.logging.Logging.Priority.WARN
 import eu.darken.apl.common.debug.logging.log
@@ -21,6 +22,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.time.Duration
+import java.time.Instant
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -164,6 +166,8 @@ class FeederRepo @Inject constructor(
                     log(TAG) { "Updating mlat stats : $it" }
                     feederStatsDatabase.mlatStats.insert(it)
                 }
+
+            feederSettings.lastUpdate.value(Instant.now())
 
             delay(1000)
         } finally {

--- a/app/src/main/java/eu/darken/apl/feeder/core/config/FeederSettings.kt
+++ b/app/src/main/java/eu/darken/apl/feeder/core/config/FeederSettings.kt
@@ -11,6 +11,7 @@ import eu.darken.apl.common.datastore.PreferenceStoreMapper
 import eu.darken.apl.common.datastore.createValue
 import eu.darken.apl.common.debug.logging.logTag
 import java.time.Duration
+import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -28,6 +29,7 @@ class FeederSettings @Inject constructor(
     val feederGroup = dataStore.createValue("feeder.group", FeederGroup(), moshi)
 
     val feederMonitorInterval = dataStore.createValue("feeder.monitor.interval", DEFAULT_CHECK_INTERVAL, moshi)
+    val lastUpdate = dataStore.createValue("feeder.update.last", Instant.EPOCH, moshi)
 
     override val mapper = PreferenceStoreMapper()
 

--- a/app/src/main/java/eu/darken/apl/feeder/ui/actions/FeederActionViewModel.kt
+++ b/app/src/main/java/eu/darken/apl/feeder/ui/actions/FeederActionViewModel.kt
@@ -82,7 +82,7 @@ class FeederActionViewModel @Inject constructor(
         val newTimeout = if (state.first().feeder.config.offlineCheckTimeout != null) {
             null
         } else {
-            Duration.ofHours(6)
+            Duration.ofHours(12)
         }
         feederRepo.setOfflineCheckTimeout(feederId, newTimeout)
     }


### PR DESCRIPTION
- The `lastUpdate` timestamp is now stored in `FeederSettings` after each successful `FeederRepo.refresh()` operation.
- The `FeederMonitor` now considers the `lastUpdate` timestamp when checking for offline devices. If the data itself is older than the configured `offlineCheckTimeout`, the device won't be marked as offline. This prevents false positives if the app hasn't been able to refresh data recently.
- The default timeout for offline checks in `FeederActionViewModel` has been increased from 6 to 12 hours.