### PR TITLE
Fix: Improve map geolocation functionality

### DIFF
--- a/app/src/main/java/eu/darken/apl/map/core/MapHandler.kt
+++ b/app/src/main/java/eu/darken/apl/map/core/MapHandler.kt
@@ -82,6 +82,7 @@ class MapHandler @AssistedInject constructor(
                 javaScriptEnabled = true
                 javaScriptCanOpenWindowsAutomatically = false
                 setGeolocationEnabled(true)
+                domStorageEnabled = true
             }
             webChromeClient = object : WebChromeClient() {
                 override fun onGeolocationPermissionsShowPrompt(
@@ -89,7 +90,7 @@ class MapHandler @AssistedInject constructor(
                     callback: GeolocationPermissions.Callback,
                 ) {
                     log(TAG) { "onGeolocationPermissionsShowPrompt($origin,$callback)" }
-                    callback.invoke(origin, true, false)
+                    callback.invoke(origin, true, true)
                 }
 
                 override fun onConsoleMessage(message: ConsoleMessage): Boolean {

--- a/app/src/main/java/eu/darken/apl/map/ui/MapFragment.kt
+++ b/app/src/main/java/eu/darken/apl/map/ui/MapFragment.kt
@@ -37,7 +37,6 @@ class MapFragment : Fragment3(R.layout.map_fragment) {
             ActivityResultContracts.RequestPermission()
         ) { isGranted: Boolean ->
             log(TAG) { "locationPermissionLauncher: $isGranted" }
-            if (isGranted) vm.homeMap()
         }
         super.onCreate(savedInstanceState)
     }


### PR DESCRIPTION
This commit addresses issues with map geolocation by:

- Enabling DOM Storage in WebView settings (`setDomStorageEnabled(true)`).
- Persisting geolocation permissions in WebView (`callback.invoke(origin, true, true)`).
- Removing the automatic call to `vm.homeMap()` after location permission is granted in `MapFragment`. This prevents unnecessary map recentering when permission is already granted and the user is interacting with the map.

Closes #5