### PR TITLE
Set 'map' as the start destination in bottom navigation

### DIFF
--- a/app/src/main/res/navigation/bottom_navigation.xml
+++ b/app/src/main/res/navigation/bottom_navigation.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/bottom_navigation"
-    app:startDestination="@id/feeder">
+    app:startDestination="@id/map">
 
     <fragment
         android:id="@+id/feeder"


### PR DESCRIPTION
The default start destination for the bottom navigation has been changed from 'feeder' to 'map'.