### PR TITLE
feat: Add fullscreen mode to map

### DIFF
--- a/app/src/main/java/eu/darken/apl/map/ui/MapFragment.kt
+++ b/app/src/main/java/eu/darken/apl/map/ui/MapFragment.kt
@@ -3,10 +3,14 @@ package eu.darken.apl.map.ui
 import android.Manifest
 import android.os.Bundle
 import android.view.View
+import android.view.WindowInsets
+import android.view.WindowInsetsController
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
+import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.apl.R
@@ -30,6 +34,8 @@ class MapFragment : Fragment3(R.layout.map_fragment) {
 
     @Inject lateinit var mapHandlerFactory: MapHandler.Factory
 
+    private var isFullscreen = false
+
     private lateinit var locationPermissionLauncher: ActivityResultLauncher<String>
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -39,9 +45,43 @@ class MapFragment : Fragment3(R.layout.map_fragment) {
             log(TAG) { "locationPermissionLauncher: $isGranted" }
         }
         super.onCreate(savedInstanceState)
+
+        // Restore fullscreen state if it was saved
+        savedInstanceState?.let {
+            isFullscreen = it.getBoolean(KEY_FULLSCREEN, false)
+        }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        // Save fullscreen state
+        outState.putBoolean(KEY_FULLSCREEN, isFullscreen)
+    }
+
+    private fun getBottomNavigationView(): BottomNavigationView? {
+        val parentFragment = parentFragment?.parentFragment
+        return parentFragment?.view?.findViewById(R.id.bottom_navigation)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+
+        ui.fullscreenButton.setOnClickListener { toggleFullscreen() }
+
+        if (isFullscreen) {
+            ui.toolbar.visibility = View.GONE
+            val params = ui.webview.layoutParams as androidx.constraintlayout.widget.ConstraintLayout.LayoutParams
+            params.topToTop = androidx.constraintlayout.widget.ConstraintLayout.LayoutParams.PARENT_ID
+            ui.webview.layoutParams = params
+            ui.fullscreenButton.icon = ContextCompat.getDrawable(
+                requireContext(),
+                R.drawable.ic_fullscreen_exit_24
+            )
+            getBottomNavigationView()?.visibility = View.GONE
+            setImmersiveMode(true)
+        } else {
+            ui.fullscreenButton.icon = ContextCompat.getDrawable(requireContext(), R.drawable.ic_fullscreen_24)
+        }
+
         ui.toolbar.apply {
             setOnMenuItemClickListener {
                 when (it.itemId) {
@@ -59,6 +99,7 @@ class MapFragment : Fragment3(R.layout.map_fragment) {
                         vm.reset()
                         true
                     }
+
 
                     else -> false
                 }
@@ -115,7 +156,67 @@ class MapFragment : Fragment3(R.layout.map_fragment) {
         ui.webview.onPause()
     }
 
+    private fun setImmersiveMode(enable: Boolean) {
+        val window = requireActivity().window
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+            window.setDecorFitsSystemWindows(!enable)
+            window.insetsController?.let {
+                if (enable) {
+                    it.hide(WindowInsets.Type.statusBars() or WindowInsets.Type.navigationBars())
+                    it.systemBarsBehavior = WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+                } else {
+                    it.show(WindowInsets.Type.statusBars() or WindowInsets.Type.navigationBars())
+                }
+            }
+        } else {
+            @Suppress("DEPRECATION")
+            window.decorView.systemUiVisibility = if (enable) {
+                (View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+                        or View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                        or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                        or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                        or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                        or View.SYSTEM_UI_FLAG_FULLSCREEN)
+            } else {
+                (View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                        or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                        or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN)
+            }
+        }
+    }
+
+
+    private fun toggleFullscreen() {
+        isFullscreen = !isFullscreen
+
+        if (isFullscreen) {
+            ui.toolbar.visibility = View.GONE
+            val params = ui.webview.layoutParams as androidx.constraintlayout.widget.ConstraintLayout.LayoutParams
+            params.topToTop = androidx.constraintlayout.widget.ConstraintLayout.LayoutParams.PARENT_ID
+            ui.webview.layoutParams = params
+            ui.fullscreenButton.icon = ContextCompat.getDrawable(
+                requireContext(),
+                R.drawable.ic_fullscreen_exit_24
+            )
+            getBottomNavigationView()?.visibility = View.GONE
+            setImmersiveMode(true)
+        } else {
+            ui.toolbar.visibility = View.VISIBLE
+            val params = ui.webview.layoutParams as androidx.constraintlayout.widget.ConstraintLayout.LayoutParams
+            params.topToTop = androidx.constraintlayout.widget.ConstraintLayout.LayoutParams.UNSET
+            params.topToBottom = R.id.toolbar
+            ui.webview.layoutParams = params
+            ui.fullscreenButton.icon = ContextCompat.getDrawable(
+                requireContext(),
+                R.drawable.ic_fullscreen_24
+            )
+            getBottomNavigationView()?.visibility = View.VISIBLE
+            setImmersiveMode(false)
+        }
+    }
+
     companion object {
         private val TAG = logTag("Map", "Fragment")
+        private const val KEY_FULLSCREEN = "map_fullscreen_state"
     }
 }

--- a/app/src/main/res/drawable/ic_fullscreen_24.xml
+++ b/app/src/main/res/drawable/ic_fullscreen_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M7,14L5,14v5h5v-2L7,17v-3zM5,10h2L7,7h3L10,5L5,5v5zM17,17h-3v2h5v-5h-2v3zM14,5v2h3v3h2L19,5h-5z" />
+</vector>

--- a/app/src/main/res/drawable/ic_fullscreen_exit_24.xml
+++ b/app/src/main/res/drawable/ic_fullscreen_exit_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M5,16h3v3h2v-5L5,14v2zM8,8L5,8v2h5L10,5L8,5v3zM14,19h2v-3h3v-2h-5v5zM16,8L16,5h-2v5h5L19,8h-3z" />
+</vector>

--- a/app/src/main/res/layout/map_fragment.xml
+++ b/app/src/main/res/layout/map_fragment.xml
@@ -29,6 +29,17 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/toolbar" />
 
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/fullscreen_button"
+            style="@style/Widget.Material3.Button.IconButton.Filled.Tonal"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_margin="16dp"
+            android:contentDescription="@string/common_fullscreen_action"
+            app:icon="@drawable/ic_fullscreen_24"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/toolbar" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/menu/menu_map.xml
+++ b/app/src/main/res/menu/menu_map.xml
@@ -17,6 +17,7 @@
         android:title="@string/common_refresh_action"
         app:showAsAction="ifRoom" />
 
+
     <item
         android:id="@+id/action_settings"
         android:orderInCategory="100"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="common_reset_action">Reset</string>
     <string name="common_add_action">Add</string>
     <string name="common_remove_action">Remove</string>
+    <string name="common_fullscreen_action">Fullscreen</string>
     <string name="common_photo_author_label">by %s</string>
     <string name="common_grant_permission_action">Grant permission</string>
     <string name="common_dismiss_action">Dismiss</string>


### PR DESCRIPTION
Closes #6

This commit introduces a fullscreen mode to the map view:

- **Toggle Fullscreen**: A new fullscreen button is added to the map toolbar to enter and exit fullscreen mode.
- **UI Adjustments**:
    - In fullscreen mode, the toolbar and bottom navigation are hidden.
    - The WebView is adjusted to take up the entire screen.
    - The system status and navigation bars are hidden (immersive mode).
- **Gesture Exit**: Tapping the map in fullscreen mode exits fullscreen.
- **State Persistence**: The fullscreen state is saved and restored across configuration changes.
- **New Icons**: Added `ic_fullscreen_24.xml` and `ic_fullscreen_exit_24.xml` for the toggle button.
- **New String**: Added `common_fullscreen_action` for the fullscreen button title.