### PR TITLE
Feat: Add local feeder detection

### DIFF
--- a/app/src/main/java/eu/darken/apl/feeder/core/api/FeedStatus.kt
+++ b/app/src/main/java/eu/darken/apl/feeder/core/api/FeedStatus.kt
@@ -1,0 +1,25 @@
+package eu.darken.apl.feeder.core.api
+
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import java.util.UUID
+
+@Serializable
+data class FeedStatus(
+    @SerialName("beast_clients") val beastClients: List<BeastClient>,
+    @SerialName("mlat_clients") val mlatClients: List<MlatClient>,
+) {
+
+    @Serializable
+    data class BeastClient(
+        @Contextual @SerialName("uuid") val uuid: UUID,
+        @SerialName("host") val host: String,
+    )
+
+    @Serializable
+    data class MlatClient(
+        @SerialName("user") val user: String,
+        @Contextual @SerialName("uuid") val uuid: UUID,
+    )
+}

--- a/app/src/main/java/eu/darken/apl/feeder/core/api/FeederApi.kt
+++ b/app/src/main/java/eu/darken/apl/feeder/core/api/FeederApi.kt
@@ -8,4 +8,7 @@ interface FeederApi {
     @GET("feed")
     suspend fun getFeeder(@Query("id", encoded = true) id: String): FeedInfos
 
+    @GET("feed-status")
+    suspend fun getFeedStatus(): FeedStatus
+
 }

--- a/app/src/main/java/eu/darken/apl/feeder/core/api/FeederEndpoint.kt
+++ b/app/src/main/java/eu/darken/apl/feeder/core/api/FeederEndpoint.kt
@@ -43,6 +43,11 @@ class FeederEndpoint @Inject constructor(
         }
     }
 
+    suspend fun getFeedStatus(): FeedStatus = withContext(dispatcherProvider.IO) {
+        log(TAG) { "getFeedStatus()" }
+        api.getFeedStatus()
+    }
+
     companion object {
         private val TAG = logTag("Feeder", "Endpoint")
     }

--- a/app/src/main/java/eu/darken/apl/feeder/ui/add/AddFeederEvents.kt
+++ b/app/src/main/java/eu/darken/apl/feeder/ui/add/AddFeederEvents.kt
@@ -2,4 +2,10 @@ package eu.darken.apl.feeder.ui.add
 
 sealed class AddFeederEvents {
     object StopCamera : AddFeederEvents()
+    data class ShowLocalDetectionResult(val result: LocalDetectionResult) : AddFeederEvents()
+}
+
+enum class LocalDetectionResult {
+    FOUND,
+    NOT_FOUND
 }

--- a/app/src/main/java/eu/darken/apl/feeder/ui/add/AddFeederFragment.kt
+++ b/app/src/main/java/eu/darken/apl/feeder/ui/add/AddFeederFragment.kt
@@ -73,6 +73,10 @@ class AddFeederFragment : Fragment3(R.layout.add_feeder_fragment) {
 
         ui.scanQrButton.setOnClickListener { startQrCodeScanning() }
 
+        ui.detectLocalButton.setOnClickListener {
+            vm.detectLocalFeeder()
+        }
+
         ui.feederId.doAfterTextChanged { text ->
             vm.updateReceiverId(text.toString())
         }
@@ -99,11 +103,12 @@ class AddFeederFragment : Fragment3(R.layout.add_feeder_fragment) {
             }
 
             // Handle loading state
-            val isEnabled = !state.isLoading
+            val isEnabled = !state.isLoading && !state.isDetectingLocal
             feederId.isEnabled = isEnabled
             feederLabel.isEnabled = isEnabled
             feederIpAddress.isEnabled = isEnabled
             scanQrButton.isEnabled = isEnabled
+            detectLocalButton.isEnabled = isEnabled
 
             // Handle button and progress indicator
             if (state.isLoading) {
@@ -116,11 +121,25 @@ class AddFeederFragment : Fragment3(R.layout.add_feeder_fragment) {
                 progressIndicator.visibility = View.GONE
                 addButton.isEnabled = state.isAddButtonEnabled
             }
+
+            // Handle local detection button state
+            if (state.isDetectingLocal) {
+                detectLocalButton.text = getString(R.string.feeder_list_detecting_local_feeder)
+            } else {
+                detectLocalButton.text = getString(R.string.feeder_list_detect_local_title)
+            }
         }
 
         vm.events.observeWith(ui) { event ->
             when (event) {
                 is AddFeederEvents.StopCamera -> stopCameraPreview()
+                is AddFeederEvents.ShowLocalDetectionResult -> {
+                    val message = when (event.result) {
+                        LocalDetectionResult.FOUND -> getString(R.string.feeder_list_local_feeder_found)
+                        LocalDetectionResult.NOT_FOUND -> getString(R.string.feeder_list_no_local_feeder_found)
+                    }
+                    Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show()
+                }
             }
         }
 

--- a/app/src/main/res/layout/add_feeder_fragment.xml
+++ b/app/src/main/res/layout/add_feeder_fragment.xml
@@ -123,6 +123,7 @@
             <com.google.android.material.card.MaterialCardView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_marginBottom="20dp"
                 app:cardCornerRadius="12dp"
                 app:cardElevation="2dp"
                 app:strokeWidth="0dp">
@@ -158,6 +159,52 @@
                         android:textSize="15sp"
                         app:cornerRadius="8dp"
                         app:icon="@drawable/ic_qr_code_scanner_24"
+                        app:iconGravity="textStart"
+                        app:iconPadding="8dp" />
+
+                </LinearLayout>
+
+            </com.google.android.material.card.MaterialCardView>
+
+            <!-- Local Detection Card -->
+            <com.google.android.material.card.MaterialCardView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:cardCornerRadius="12dp"
+                app:cardElevation="2dp"
+                app:strokeWidth="0dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="16dp">
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="8dp"
+                        android:text="@string/feeder_list_local_detection_title"
+                        android:textAppearance="?attr/textAppearanceTitleMedium"
+                        android:textColor="?attr/colorOnSurface" />
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="12dp"
+                        android:text="@string/feeder_list_local_detection_description"
+                        android:textAppearance="?attr/textAppearanceBodyMedium"
+                        android:textColor="?attr/colorOnSurfaceVariant" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/detect_local_button"
+                        style="@style/Widget.Material3.Button.TonalButton"
+                        android:layout_width="match_parent"
+                        android:layout_height="48dp"
+                        android:text="@string/feeder_list_detect_local_title"
+                        android:textSize="15sp"
+                        app:cornerRadius="8dp"
+                        app:icon="@drawable/ic_router_wireless_24"
                         app:iconGravity="textStart"
                         app:iconPadding="8dp" />
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -120,6 +120,12 @@
     <string name="feeder_list_quick_setup_description">Scanne einen QR-Code, um alle Felder automatisch auszufüllen</string>
     <string name="feeder_list_feeder_id_helper">Erforderlich: Die UUID deines Feeders</string>
     <string name="feeder_list_camera_error">Fehler beim Starten der Kamera: %s</string>
+    <string name="feeder_list_local_detection_title">Lokale Erkennung</string>
+    <string name="feeder_list_local_detection_description">Feeder im selben Netzwerk erkennen</string>
+    <string name="feeder_list_detect_local_title">Lokalen Feeder erkennen</string>
+    <string name="feeder_list_detecting_local_feeder">Erkenne lokalen Feeder...</string>
+    <string name="feeder_list_no_local_feeder_found">Kein lokaler Feeder gefunden</string>
+    <string name="feeder_list_local_feeder_found">Lokaler Feeder erkannt und Felder ausgefüllt</string>
     <string name="feeder_beast_stats_label">Beast-Statistiken</string>
     <string name="feeder_mlat_stats_label">MLAT-Statistiken</string>
     <string name="feeder_monitor_offline_label">Benachrichtigen, wenn offline</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -122,6 +122,12 @@
     <string name="feeder_list_feeder_id_helper">Requerido: El UUID de tu alimentador</string>
     <string name="feeder_list_camera_error">Error al iniciar la cámara: %s</string>
     <string name="feeder_list_scan_qr_title">Escanear código QR</string>
+    <string name="feeder_list_local_detection_title">Detección Local</string>
+    <string name="feeder_list_local_detection_description">Detectar alimentadores en la misma red</string>
+    <string name="feeder_list_detect_local_title">Detectar Alimentador Local</string>
+    <string name="feeder_list_detecting_local_feeder">Detectando alimentador local...</string>
+    <string name="feeder_list_no_local_feeder_found">No se encontró alimentador local</string>
+    <string name="feeder_list_local_feeder_found">Alimentador local detectado y campos rellenados</string>
     <string name="feeder_list_camera_permission_required_title">Permiso de cámara requerido</string>
     <string name="feeder_list_camera_permission_required_message">Se requiere permiso de cámara para escanear códigos QR.</string>
     <string name="feeder_list_invalid_qr_code_title">Código QR inválido</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -122,6 +122,12 @@
     <string name="feeder_list_feeder_id_helper">Requis: L\'UUID de votre alimentateur</string>
     <string name="feeder_list_camera_error">Erreur lors du démarrage de la caméra: %s</string>
     <string name="feeder_list_scan_qr_title">Scanner le code QR</string>
+    <string name="feeder_list_local_detection_title">Détection Locale</string>
+    <string name="feeder_list_local_detection_description">Détecter les alimentateurs sur le même réseau</string>
+    <string name="feeder_list_detect_local_title">Détecter l\'Alimentateur Local</string>
+    <string name="feeder_list_detecting_local_feeder">Détection de l\'alimentateur local...</string>
+    <string name="feeder_list_no_local_feeder_found">Aucun alimentateur local trouvé</string>
+    <string name="feeder_list_local_feeder_found">Alimentateur local détecté et champs remplis</string>
     <string name="feeder_list_camera_permission_required_title">Permission de caméra requise</string>
     <string name="feeder_list_camera_permission_required_message">La permission de caméra est requise pour scanner les codes QR.</string>
     <string name="feeder_list_invalid_qr_code_title">Code QR invalide</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -122,6 +122,12 @@
     <string name="feeder_list_feeder_id_helper">Richiesto: L\'UUID del tuo alimentatore</string>
     <string name="feeder_list_camera_error">Errore nell\'avvio della fotocamera: %s</string>
     <string name="feeder_list_scan_qr_title">Scansiona codice QR</string>
+    <string name="feeder_list_local_detection_title">Rilevamento Locale</string>
+    <string name="feeder_list_local_detection_description">Rileva alimentatori sulla stessa rete</string>
+    <string name="feeder_list_detect_local_title">Rileva Alimentatore Locale</string>
+    <string name="feeder_list_detecting_local_feeder">Rilevamento alimentatore locale...</string>
+    <string name="feeder_list_no_local_feeder_found">Nessun alimentatore locale trovato</string>
+    <string name="feeder_list_local_feeder_found">Alimentatore locale rilevato e campi compilati</string>
     <string name="feeder_list_camera_permission_required_title">Permesso fotocamera richiesto</string>
     <string name="feeder_list_camera_permission_required_message">Il permesso della fotocamera è richiesto per scansionare i codici QR.</string>
     <string name="feeder_list_invalid_qr_code_title">Codice QR non valido</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -124,6 +124,12 @@
     <string name="feeder_list_feeder_id_helper">Обязательно: UUID вашего фидера</string>
     <string name="feeder_list_camera_error">Ошибка запуска камеры: %s</string>
     <string name="feeder_list_scan_qr_title">Сканировать QR-код</string>
+    <string name="feeder_list_local_detection_title">Локальное Обнаружение</string>
+    <string name="feeder_list_local_detection_description">Обнаружить фидеры в той же сети</string>
+    <string name="feeder_list_detect_local_title">Обнаружить Локальный Фидер</string>
+    <string name="feeder_list_detecting_local_feeder">Обнаружение локального фидера...</string>
+    <string name="feeder_list_no_local_feeder_found">Локальный фидер не найден</string>
+    <string name="feeder_list_local_feeder_found">Локальный фидер обнаружен и поля заполнены</string>
     <string name="feeder_list_camera_permission_required_title">Требуется разрешение камеры</string>
     <string name="feeder_list_camera_permission_required_message">Для сканирования QR-кодов требуется разрешение камеры.</string>
     <string name="feeder_list_invalid_qr_code_title">Неверный QR-код</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,6 +122,13 @@
     <string name="feeder_list_feeder_id_helper">Required: Your feeder\'s UUID</string>
     <string name="feeder_list_camera_error">Error starting camera: %s</string>
     <string name="feeder_list_scan_qr_title">Scan QR Code</string>
+    <string name="feeder_list_local_detection_title">Local Detection</string>
+    <string name="feeder_list_local_detection_description">Detect feeders running on the same network</string>
+    <string name="feeder_list_detect_local_title">Detect Local Feeder</string>
+    <string name="feeder_list_detecting_local_feeder">Detecting local feeder...</string>
+    <string name="feeder_list_no_local_feeder_found">No local feeder found</string>
+    <string name="feeder_list_local_feeder_found">Local feeder detected and fields filled</string>
+
     <string name="feeder_list_camera_permission_required_title">Camera Permission Required</string>
     <string name="feeder_list_camera_permission_required_message">Camera permission is required to scan QR codes.</string>
     <string name="feeder_list_invalid_qr_code_title">Invalid QR Code</string>

--- a/buildSrc/.gitignore
+++ b/buildSrc/.gitignore
@@ -1,2 +1,3 @@
 .gradle/
 build/
+.kotlin/sessions


### PR DESCRIPTION
This commit introduces a new feature to detect and pre-fill feeder information when the app is on the same network as a feeder.

- Added a "Detect Local Feeder" button to the "Add Feeder" screen.
- Implemented logic to query a local `/feed-status` endpoint.
- If a feeder is found, its UUID, IP address, and label are automatically populated.
- Added new string resources for the feature and its translations.