### PR TITLE
Include position in NewFeederQR

### DIFF
--- a/app/src/main/java/eu/darken/apl/feeder/ui/actions/FeederActionDialog.kt
+++ b/app/src/main/java/eu/darken/apl/feeder/ui/actions/FeederActionDialog.kt
@@ -7,6 +7,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.graphics.createBitmap
+import androidx.core.graphics.set
 import androidx.core.view.isGone
 import androidx.fragment.app.viewModels
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -31,8 +33,7 @@ class FeederActionDialog : BottomSheetDialogFragment2() {
     override val vm: FeederActionViewModel by viewModels()
     override lateinit var ui: FeederActionDialogBinding
 
-    @Inject
-    lateinit var json: Json
+    @Inject lateinit var json: Json
 
     private val permissionlauncher = registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
 
@@ -153,10 +154,10 @@ class FeederActionDialog : BottomSheetDialogFragment2() {
     private fun createBitmapFromBitMatrix(matrix: BitMatrix): Bitmap {
         val width = matrix.width
         val height = matrix.height
-        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.RGB_565)
+        val bitmap = createBitmap(width, height, Bitmap.Config.RGB_565)
         for (x in 0 until width) {
             for (y in 0 until height) {
-                bitmap.setPixel(x, y, if (matrix[x, y]) Color.BLACK else Color.WHITE)
+                bitmap[x, y] = if (matrix[x, y]) Color.BLACK else Color.WHITE
             }
         }
         return bitmap

--- a/app/src/main/java/eu/darken/apl/feeder/ui/actions/FeederActionViewModel.kt
+++ b/app/src/main/java/eu/darken/apl/feeder/ui/actions/FeederActionViewModel.kt
@@ -23,7 +23,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.take
-import kotlinx.serialization.json.Json
 import java.net.Inet4Address
 import java.net.InetAddress
 import java.time.Duration
@@ -38,7 +37,6 @@ class FeederActionViewModel @Inject constructor(
     dispatcherProvider: DispatcherProvider,
     private val feederRepo: FeederRepo,
     private val webpageTool: WebpageTool,
-    private val json: Json,
 ) : ViewModel3(
     dispatcherProvider,
     tag = logTag("Feeder", "Action", "Dialog", "ViewModel"),
@@ -143,7 +141,8 @@ class FeederActionViewModel @Inject constructor(
         val qr = NewFeederQR(
             receiverId = feederId,
             receiverLabel = feeder.label,
-            receiverIpv4Address = feeder.config.address
+            receiverIpv4Address = feeder.config.address,
+            position = feeder.config.position
         )
         log(tag) { "generateQrCode(): $feeder -> $qr" }
         events.emit(FeederActionEvents.ShowQrCode(qr))

--- a/app/src/main/java/eu/darken/apl/feeder/ui/add/AddFeederViewModel.kt
+++ b/app/src/main/java/eu/darken/apl/feeder/ui/add/AddFeederViewModel.kt
@@ -19,7 +19,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class AddFeederViewModel @Inject constructor(
-    private val handle: SavedStateHandle,
+    handle: SavedStateHandle,
     dispatcherProvider: DispatcherProvider,
     private val feederRepo: FeederRepo,
     private val feederEndpoint: FeederEndpoint,
@@ -53,7 +53,7 @@ class AddFeederViewModel @Inject constructor(
         val isValidInput = try {
             UUID.fromString(id.trim())
             id.trim().isNotBlank()
-        } catch (e: IllegalArgumentException) {
+        } catch (_: IllegalArgumentException) {
             false
         }
 
@@ -92,7 +92,7 @@ class AddFeederViewModel @Inject constructor(
                         val longitude = parts[1].toDouble()
                         FeederPosition(latitude = latitude, longitude = longitude)
                     } else null
-                } catch (e: NumberFormatException) {
+                } catch (_: NumberFormatException) {
                     null
                 }
                 if (position != null) {
@@ -181,6 +181,9 @@ class AddFeederViewModel @Inject constructor(
         updateReceiverId(feederQR.receiverId)
         updateReceiverLabel(feederQR.receiverLabel ?: "")
         updateReceiverIpAddress(feederQR.receiverIpv4Address ?: "")
+        feederQR.position?.let { position ->
+            updateReceiverPosition("${position.latitude}, ${position.longitude}")
+        }
 
         events.tryEmit(AddFeederEvents.StopCamera)
     }

--- a/app/src/main/java/eu/darken/apl/feeder/ui/add/NewFeederQR.kt
+++ b/app/src/main/java/eu/darken/apl/feeder/ui/add/NewFeederQR.kt
@@ -2,6 +2,7 @@ package eu.darken.apl.feeder.ui.add
 
 import android.net.Uri
 import eu.darken.apl.feeder.core.ReceiverId
+import eu.darken.apl.feeder.core.config.FeederPosition
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
@@ -12,6 +13,7 @@ data class NewFeederQR(
     @SerialName("receiverId") val receiverId: ReceiverId,
     @SerialName("receiverLabel") val receiverLabel: String? = null,
     @SerialName("receiverIpv4Address") val receiverIpv4Address: String? = null,
+    @SerialName("position") val position: FeederPosition? = null,
 ) {
     fun toUri(json: Json): Uri {
         val jsonData = json.encodeToString(this)

--- a/app/src/test/java/eu/darken/apl/feeder/ui/add/NewFeederQRTest.kt
+++ b/app/src/test/java/eu/darken/apl/feeder/ui/add/NewFeederQRTest.kt
@@ -1,6 +1,7 @@
 package eu.darken.apl.feeder.ui.add
 
 import eu.darken.apl.common.serialization.SerializationModule
+import eu.darken.apl.feeder.core.config.FeederPosition
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import kotlinx.serialization.encodeToString
@@ -55,7 +56,8 @@ class NewFeederQRTest {
     fun `JSON serialization produces expected format`() {
         val feederQR = NewFeederQR(
             receiverId = "receiver789",
-            receiverLabel = "My Custom Feeder"
+            receiverLabel = "My Custom Feeder",
+            position = FeederPosition(latitude = 40.7128, longitude = -74.0060)
         )
 
         val jsonString = json.encodeToString(feederQR)
@@ -63,7 +65,11 @@ class NewFeederQRTest {
         jsonString.toComparableJson() shouldBe """
             {
                 "receiverId": "receiver789",
-                "receiverLabel": "My Custom Feeder"
+                "receiverLabel": "My Custom Feeder",
+                "position": {
+                    "latitude": 40.7128,
+                    "longitude": -74.0060
+                }
             }
         """.toComparableJson()
     }
@@ -147,7 +153,8 @@ class NewFeederQRTest {
     fun `URI can be parsed back to original data`() {
         val originalQR = NewFeederQR(
             receiverId = "roundtrip-test",
-            receiverLabel = "Round Trip Label"
+            receiverLabel = "Round Trip Label",
+            position = FeederPosition(latitude = 51.5074, longitude = -0.1278)
         )
 
         val uri = originalQR.toUri(json)
@@ -156,5 +163,7 @@ class NewFeederQRTest {
 
         parsedQR.receiverId shouldBe originalQR.receiverId
         parsedQR.receiverLabel shouldBe originalQR.receiverLabel
+        parsedQR.position?.latitude shouldBe originalQR.position?.latitude
+        parsedQR.position?.longitude shouldBe originalQR.position?.longitude
     }
 }


### PR DESCRIPTION
The `FeederPosition` has been added to the `NewFeederQR` data class. This allows the QR code to optionally include the feeder's geographical coordinates.

The changes affect:
- `NewFeederQR`: Added `position` field.
- `FeederActionViewModel`: Includes `position` when generating QR codes.
- `AddFeederViewModel`: Populates the position field when a QR code with position data is scanned.
- `NewFeederQRTest`: Updated tests to include position data.