### PR TITLE
Refactor offline check and add list header

### DIFF
--- a/app/src/main/java/eu/darken/apl/feeder/core/Feeder.kt
+++ b/app/src/main/java/eu/darken/apl/feeder/core/Feeder.kt
@@ -3,7 +3,6 @@ package eu.darken.apl.feeder.core
 import eu.darken.apl.feeder.core.config.FeederConfig
 import eu.darken.apl.feeder.core.stats.BeastStatsEntity
 import eu.darken.apl.feeder.core.stats.MlatStatsEntity
-import java.time.Duration
 import java.time.Instant
 
 data class Feeder(
@@ -14,13 +13,6 @@ data class Feeder(
 
     val label: String
         get() = config.label ?: config.receiverId.takeLast(5)
-
-    val isOffline: Boolean
-        get() = if (config.offlineCheckTimeout != null) {
-            Duration.between(lastSeen, Instant.now()) > config.offlineCheckTimeout
-        } else {
-            false
-        }
 
     val lastSeen: Instant?
         get() = listOfNotNull(beastStats?.receivedAt).maxOrNull()

--- a/app/src/main/java/eu/darken/apl/feeder/core/config/FeederSettings.kt
+++ b/app/src/main/java/eu/darken/apl/feeder/core/config/FeederSettings.kt
@@ -1,6 +1,5 @@
 package eu.darken.apl.feeder.core.config
 
-// Import the specific createValue function from DataStoreValueSerialization
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences

--- a/app/src/main/java/eu/darken/apl/feeder/core/monitor/FeederMonitor.kt
+++ b/app/src/main/java/eu/darken/apl/feeder/core/monitor/FeederMonitor.kt
@@ -1,6 +1,5 @@
 package eu.darken.apl.feeder.core.monitor
 
-import eu.darken.apl.common.datastore.value
 import eu.darken.apl.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.apl.common.debug.logging.Logging.Priority.INFO
 import eu.darken.apl.common.debug.logging.asLog
@@ -9,8 +8,6 @@ import eu.darken.apl.common.debug.logging.logTag
 import eu.darken.apl.feeder.core.FeederRepo
 import eu.darken.apl.feeder.core.config.FeederSettings
 import kotlinx.coroutines.flow.first
-import java.time.Duration
-import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -30,16 +27,7 @@ class FeederMonitor @Inject constructor(
         }
 
         val offlineDevices = feederRepo.feeders.first()
-            .filter { it.config.offlineCheckTimeout != null }
-            .filter {
-                if (it.lastSeen == null) return@filter false
-
-                val timeSinceUpdate = Duration.between(settings.lastUpdate.value(), Instant.now())
-                if (timeSinceUpdate > it.config.offlineCheckTimeout) return@filter false
-
-                Duration.between(it.lastSeen, Instant.now()) > it.config.offlineCheckTimeout
-            }
-            .filter { it.config.offlineCheckSnoozedAt == null }
+            .filter { feederRepo.isOffline(it) }
             .onEach { log(TAG, INFO) { "Feeder has been offline for a while... $it" } }
 
         notifications.notifyOfOfflineDevices(offlineDevices)

--- a/app/src/main/java/eu/darken/apl/feeder/ui/FeederListAdapter.kt
+++ b/app/src/main/java/eu/darken/apl/feeder/ui/FeederListAdapter.kt
@@ -13,6 +13,7 @@ import eu.darken.apl.common.lists.modular.mods.DataBinderMod
 import eu.darken.apl.common.lists.modular.mods.TypedVHCreatorMod
 import eu.darken.apl.common.lists.selection.SelectableItem
 import eu.darken.apl.feeder.ui.types.DefaultFeederVH
+import eu.darken.apl.feeder.ui.types.FeederHeaderVH
 import javax.inject.Inject
 
 
@@ -26,6 +27,7 @@ class FeederListAdapter @Inject constructor() :
 
     init {
         addMod(DataBinderMod(data))
+        addMod(TypedVHCreatorMod({ data[it] is FeederHeaderVH.Item }) { FeederHeaderVH(it) })
         addMod(TypedVHCreatorMod({ data[it] is DefaultFeederVH.Item }) { DefaultFeederVH(it) })
     }
 

--- a/app/src/main/java/eu/darken/apl/feeder/ui/FeederListViewModel.kt
+++ b/app/src/main/java/eu/darken/apl/feeder/ui/FeederListViewModel.kt
@@ -9,6 +9,7 @@ import eu.darken.apl.common.debug.logging.logTag
 import eu.darken.apl.common.uix.ViewModel3
 import eu.darken.apl.feeder.core.FeederRepo
 import eu.darken.apl.feeder.ui.types.DefaultFeederVH
+import eu.darken.apl.feeder.ui.types.FeederHeaderVH
 import eu.darken.apl.map.core.AirplanesLive
 import eu.darken.apl.map.core.MapOptions
 import eu.darken.apl.map.core.toMapFeedId
@@ -39,16 +40,24 @@ class FeederListViewModel @Inject constructor(
         feederRepo.feeders,
         feederRepo.isRefreshing
     ) { _, feeders, isRefreshing ->
-        val items = feeders.map { feeder ->
+        val offlineStates = feeders.associate { it.id to feederRepo.isOffline(it) }
+
+        val feederItems = feeders.map { feeder ->
             DefaultFeederVH.Item(
                 feeder = feeder,
+                isOffline = offlineStates[feeder.id]!!,
                 onTap = {
                     FeederListFragmentDirections.actionFeederToFeederActionDialog(feeder.id).navigate()
                 },
             )
         }
+
+        val headerItem = FeederHeaderVH.Item(hasOfflineFeeders = offlineStates.any { it.value })
+
+        val allItems = listOf(headerItem) + feederItems
+
         State(
-            items = items,
+            items = allItems,
             isRefreshing = isRefreshing,
         )
     }.asStateFlow()

--- a/app/src/main/java/eu/darken/apl/feeder/ui/types/DefaultFeederVH.kt
+++ b/app/src/main/java/eu/darken/apl/feeder/ui/types/DefaultFeederVH.kt
@@ -37,7 +37,7 @@ class DefaultFeederVH(parent: ViewGroup) :
         receiverName.apply {
             text = feeder.label
             setTextColor(
-                if (feeder.isOffline) getColorForAttr(com.google.android.material.R.attr.colorError)
+                if (item.isOffline) getColorForAttr(com.google.android.material.R.attr.colorError)
                 else getColorForAttr(com.google.android.material.R.attr.colorOnBackground)
             )
         }
@@ -63,7 +63,7 @@ class DefaultFeederVH(parent: ViewGroup) :
 
         monitorIcon.isGone = feeder.config.offlineCheckTimeout == null
         monitorIcon.setImageResource(
-            if (feeder.isOffline) R.drawable.ic_fire_alert_24 else R.drawable.ic_alarm_bell_24
+            if (item.isOffline) R.drawable.ic_fire_alert_24 else R.drawable.ic_alarm_bell_24
         )
 
         root.setOnClickListener { item.onTap(item) }
@@ -71,6 +71,7 @@ class DefaultFeederVH(parent: ViewGroup) :
 
     data class Item(
         val feeder: Feeder,
+        val isOffline: Boolean,
         val onTap: (Item) -> Unit,
     ) : FeederListAdapter.Item {
         override val stableId: Long

--- a/app/src/main/java/eu/darken/apl/feeder/ui/types/FeederHeaderVH.kt
+++ b/app/src/main/java/eu/darken/apl/feeder/ui/types/FeederHeaderVH.kt
@@ -1,0 +1,38 @@
+package eu.darken.apl.feeder.ui.types
+
+import android.view.ViewGroup
+import eu.darken.apl.R
+import eu.darken.apl.common.lists.BindableVH
+import eu.darken.apl.databinding.FeederListHeaderItemBinding
+import eu.darken.apl.feeder.ui.FeederListAdapter
+
+class FeederHeaderVH(parent: ViewGroup) :
+    FeederListAdapter.BaseVH<FeederHeaderVH.Item, FeederListHeaderItemBinding>(
+        R.layout.feeder_list_header_item,
+        parent
+    ), BindableVH<FeederHeaderVH.Item, FeederListHeaderItemBinding> {
+
+    override val viewBinding = lazy { FeederListHeaderItemBinding.bind(itemView) }
+
+    override val onBindData: FeederListHeaderItemBinding.(
+        item: Item,
+        payloads: List<Any>
+    ) -> Unit = { item, _ ->
+        headerStatusText.text = if (item.hasOfflineFeeders) {
+            context.getString(R.string.feeder_status_header_some_offline)
+        } else {
+            context.getString(R.string.feeder_status_header_all_online)
+        }
+
+        headerStatusText.setTextColor(
+            if (item.hasOfflineFeeders) getColorForAttr(com.google.android.material.R.attr.colorError)
+            else getColorForAttr(com.google.android.material.R.attr.colorPrimary)
+        )
+    }
+
+    data class Item(
+        val hasOfflineFeeders: Boolean
+    ) : FeederListAdapter.Item {
+        override val stableId: Long = Item::class.java.hashCode().toLong()
+    }
+}

--- a/app/src/main/res/layout/feeder_list_header_item.xml
+++ b/app/src/main/res/layout/feeder_list_header_item.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="@style/Widget.Material3.CardView.Elevated"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="8dp"
+    android:layout_marginVertical="4dp">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/bg_listitem_selectable"
+        android:padding="16dp">
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/header_status_text"
+            style="@style/TextAppearance.Material3.TitleMedium"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="16dp"
+            android:ellipsize="end"
+            android:singleLine="true"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="All feeders online" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -162,6 +162,8 @@
     <string name="feeder_monitor_offline_message">Some of your airplanes.live feeders are offline: %s</string>
     <string name="feeder_options_label">Options</string>
     <string name="feeder_startfeeding_msg">Not feeding airplanes.live yet?\nStart now, it\'s not rocket science 🚀.</string>
+    <string name="feeder_status_header_all_online">All feeders online</string>
+    <string name="feeder_status_header_some_offline">Some feeders offline</string>
 
     <string name="feeder_settings_title">Feeder</string>
     <string name="feeder_settings_summary">Feeder related settings, e.g. monitoring interval.</string>


### PR DESCRIPTION
- Offline check logic moved to `FeederRepo.isOffline()` and considers network state and last global data update.
- Feeder list now displays a header indicating overall online/offline status.