### PR TITLE
Test: Add test for NewFeederQR URI encoding

### DIFF
--- a/app/src/test/java/eu/darken/apl/feeder/ui/add/NewFeederQRTest.kt
+++ b/app/src/test/java/eu/darken/apl/feeder/ui/add/NewFeederQRTest.kt
@@ -166,4 +166,31 @@ class NewFeederQRTest {
         parsedQR.position?.latitude shouldBe originalQR.position?.latitude
         parsedQR.position?.longitude shouldBe originalQR.position?.longitude
     }
+
+    @Test
+    fun `URI encoded JSON matches direct JSON encoding`() {
+        val feederQR = NewFeederQR(
+            receiverId = "complex-id-123",
+            receiverLabel = "Complex Feeder Name",
+            receiverIpv4Address = "192.168.1.100",
+            position = FeederPosition(latitude = 37.7749, longitude = -122.4194)
+        )
+
+        // Get direct JSON encoding
+        val directJson = json.encodeToString(feederQR)
+
+        // The expected URI string that can be copied by external reviewers
+        val expectedUriString =
+            "eu_darken_apl://feeder?data={\"receiverId\":\"complex-id-123\",\"receiverLabel\":\"Complex Feeder Name\",\"receiverIpv4Address\":\"192.168.1.100\",\"position\":{\"latitude\":37.7749,\"longitude\":-122.4194}}"
+
+        // Get URI and extract the JSON data
+        val uri = feederQR.toUri(json)
+
+        // Compare the generated URI with the expected literal URI
+        uri.toString() shouldBe expectedUriString
+
+        // Also verify the JSON data can be extracted and matches the direct encoding
+        val uriJsonData = uri.getQueryParameter("data")!!
+        uriJsonData.toComparableJson() shouldBe directJson.toComparableJson()
+    }
 }


### PR DESCRIPTION
This commit adds a new test case to `NewFeederQRTest.kt` to verify that the URI generated from a `NewFeederQR` object correctly encodes the JSON data.

The test ensures:
- The generated URI string matches an expected, manually verified URI.
- The JSON data extracted from the URI's "data" query parameter matches the JSON string obtained by directly encoding the `NewFeederQR` object.