### PR TITLE
Fix: Correct feeder count in list subtitle

### DIFF
--- a/app/src/main/java/eu/darken/apl/feeder/ui/FeederListFragment.kt
+++ b/app/src/main/java/eu/darken/apl/feeder/ui/FeederListFragment.kt
@@ -80,7 +80,7 @@ class FeederListFragment : Fragment3(R.layout.feeder_list_fragment) {
             swipeRefreshContainer.isRefreshing = state.isRefreshing
 
             adapter.update(state.items)
-            toolbar.subtitle = resources.getQuantityString(R.plurals.feeder_yours_x_active_msg, 0, state.items.size)
+            toolbar.subtitle = resources.getQuantityString(R.plurals.feeder_yours_x_active_msg, 0, state.feederCount)
         }
 
         ui.addFeederAction.setOnClickListener { goToAddFeeder() }

--- a/app/src/main/java/eu/darken/apl/feeder/ui/FeederListViewModel.kt
+++ b/app/src/main/java/eu/darken/apl/feeder/ui/FeederListViewModel.kt
@@ -58,6 +58,7 @@ class FeederListViewModel @Inject constructor(
 
         State(
             items = allItems,
+            feederCount = feederItems.size,
             isRefreshing = isRefreshing,
         )
     }.asStateFlow()
@@ -84,6 +85,7 @@ class FeederListViewModel @Inject constructor(
 
     data class State(
         val items: List<FeederListAdapter.Item>,
+        val feederCount: Int,
         val isRefreshing: Boolean = false,
     )
 


### PR DESCRIPTION
The subtitle in the feeder list now accurately reflects the number of feeders, not the total number of items including headers.