### PR TITLE
Disable dependency metadata in APKs and Bundles

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -146,6 +146,13 @@ android {
     ksp {
         arg("room.schemaLocation", "$projectDir/schemas")
     }
+
+    dependenciesInfo {
+        // Disables dependency metadata when building APKs (for IzzyOnDroid/F-Droid)
+        includeInApk = false
+        // Disables dependency metadata when building Android App Bundles (for Google Play)
+        includeInBundle = false
+    }
 }
 
 dependencies {


### PR DESCRIPTION
This commit configures the `dependenciesInfo` block in `app/build.gradle.kts` to disable the inclusion of dependency metadata in both APK and Android App Bundle builds. This is primarily for builds targeting F-Droid (via IzzyOnDroid) and Google Play.

See https://github.com/d4rken/airplanes-live-app/issues/37#issuecomment-3003704272