### PR TITLE
Refactor: Make Mlat UUID nullable

### DIFF
--- a/app/src/main/java/eu/darken/apl/feeder/core/api/FeedInfos.kt
+++ b/app/src/main/java/eu/darken/apl/feeder/core/api/FeedInfos.kt
@@ -25,7 +25,7 @@ data class FeedInfos(
     @Serializable
     data class Mlat(
         @SerialName("user") val user: String,
-        @Contextual @SerialName("uuid") val uuid: UUID,
+        @Contextual @SerialName("uuid") val uuid: UUID?,
         @SerialName("message_rate") val messageRate: Double,
         @SerialName("peer_count") val peerCount: Int,
         @SerialName("bad_sync_timeout") val badSyncTimeout: Long,


### PR DESCRIPTION
The `uuid` field in the `Mlat` data class is now nullable to handle cases where it might not be present in the API response.