### PR TITLE
Update default offline limit for feeders

### DIFF
--- a/app/src/main/java/eu/darken/apl/feeder/core/config/FeederConfig.kt
+++ b/app/src/main/java/eu/darken/apl/feeder/core/config/FeederConfig.kt
@@ -18,6 +18,6 @@ data class FeederConfig(
     @SerialName("address") val address: String? = null,
 ) {
     companion object {
-        val DEFAULT_OFFLINE_LIMIT = Duration.ofHours(12)
+        val DEFAULT_OFFLINE_LIMIT = Duration.ofHours(48)
     }
 }


### PR DESCRIPTION
The default offline limit for feeders has been increased from 12 to 48 hours.