### PR TITLE
Add "Restore last view" setting to remember map position

### DIFF
--- a/app/src/main/java/eu/darken/apl/map/core/MapHandler.kt
+++ b/app/src/main/java/eu/darken/apl/map/core/MapHandler.kt
@@ -55,7 +55,16 @@ class MapHandler @AssistedInject constructor(
                         ?.filter { it.isNotEmpty() }
                         ?.toSet()
                         ?: emptySet(),
-                )
+                ),
+            )
+            sendEvent(Event.OptionsChanged(currentOptions))
+        }
+
+        override fun onMapPositionChanged(lat: Double, lon: Double, zoom: Double) {
+            log(TAG) { "onMapPositionChanged(lat=$lat, lon=$lon, zoom=$zoom)" }
+            val old = currentOptions
+            currentOptions = old.copy(
+                camera = MapOptions.Camera(lat, lon, zoom)
             )
             sendEvent(Event.OptionsChanged(currentOptions))
         }
@@ -135,6 +144,7 @@ class MapHandler @AssistedInject constructor(
         if (url.contains("globe.airplanes.live")) {
             view.setupUrlChangeHook()
             view.setupButtonHook("H", "onHomePressed")
+            view.setupMapPositionHook()
             view.setupAddWatch()
             view.setupShowInSearch()
         } else {

--- a/app/src/main/java/eu/darken/apl/map/core/MapSettings.kt
+++ b/app/src/main/java/eu/darken/apl/map/core/MapSettings.kt
@@ -9,12 +9,15 @@ import eu.darken.apl.common.datastore.PreferenceScreenData
 import eu.darken.apl.common.datastore.PreferenceStoreMapper
 import eu.darken.apl.common.datastore.createValue
 import eu.darken.apl.common.debug.logging.logTag
+import kotlinx.serialization.json.Json
 import javax.inject.Inject
 import javax.inject.Singleton
+import eu.darken.apl.common.datastore.createValue as createJsonValue
 
 @Singleton
 class MapSettings @Inject constructor(
     @param:ApplicationContext private val context: Context,
+    private val json: Json,
 ) : PreferenceScreenData {
 
     private val Context.dataStore by preferencesDataStore(name = "settings_map")
@@ -22,10 +25,11 @@ class MapSettings @Inject constructor(
     override val dataStore: DataStore<Preferences>
         get() = context.dataStore
 
-    val lastUrl = dataStore.createValue("map.last.url", null as String?)
+    val isRestoreLastViewEnabled = dataStore.createValue("map.restore.last.view.enabled", true)
+    val lastCamera = dataStore.createJsonValue<SavedCamera?>("map.last.camera", null, json)
 
     override val mapper = PreferenceStoreMapper(
-        lastUrl,
+        isRestoreLastViewEnabled,
     )
 
     companion object {

--- a/app/src/main/java/eu/darken/apl/map/core/MapWebInterface.kt
+++ b/app/src/main/java/eu/darken/apl/map/core/MapWebInterface.kt
@@ -13,6 +13,7 @@ class MapWebInterface @AssistedInject constructor(
     interface Listener {
         fun onHomePressed()
         fun onUrlChanged(newUrl: String)
+        fun onMapPositionChanged(lat: Double, lon: Double, zoom: Double)
         fun onShowInSearch(hex: AircraftHex)
         fun onAddWatch(hex: AircraftHex)
         fun getWatchCount(hex: AircraftHex): Int
@@ -26,6 +27,11 @@ class MapWebInterface @AssistedInject constructor(
     @JavascriptInterface
     fun onUrlChanged(newUrl: String) {
         listener.onUrlChanged(newUrl)
+    }
+
+    @JavascriptInterface
+    fun onMapPositionChanged(lat: Double, lon: Double, zoom: Double) {
+        listener.onMapPositionChanged(lat, lon, zoom)
     }
 
     @JavascriptInterface

--- a/app/src/main/java/eu/darken/apl/map/core/SavedCamera.kt
+++ b/app/src/main/java/eu/darken/apl/map/core/SavedCamera.kt
@@ -1,0 +1,16 @@
+package eu.darken.apl.map.core
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SavedCamera(
+    val lat: Double,
+    val lon: Double,
+    val zoom: Double,
+) {
+    fun toCamera(): MapOptions.Camera = MapOptions.Camera(lat, lon, zoom)
+
+    companion object {
+        fun from(camera: MapOptions.Camera): SavedCamera = SavedCamera(camera.lat, camera.lon, camera.zoom)
+    }
+}

--- a/app/src/main/java/eu/darken/apl/map/ui/settings/MapSettingsFragment.kt
+++ b/app/src/main/java/eu/darken/apl/map/ui/settings/MapSettingsFragment.kt
@@ -1,0 +1,21 @@
+package eu.darken.apl.map.ui.settings
+
+import androidx.annotation.Keep
+import androidx.fragment.app.viewModels
+import dagger.hilt.android.AndroidEntryPoint
+import eu.darken.apl.R
+import eu.darken.apl.common.uix.PreferenceFragment2
+import eu.darken.apl.map.core.MapSettings
+import javax.inject.Inject
+
+@Keep
+@AndroidEntryPoint
+class MapSettingsFragment : PreferenceFragment2() {
+
+    private val vm: MapSettingsViewModel by viewModels()
+
+    @Inject lateinit var mapSettings: MapSettings
+
+    override val settings: MapSettings by lazy { mapSettings }
+    override val preferenceFile: Int = R.xml.preferences_map
+}

--- a/app/src/main/java/eu/darken/apl/map/ui/settings/MapSettingsViewModel.kt
+++ b/app/src/main/java/eu/darken/apl/map/ui/settings/MapSettingsViewModel.kt
@@ -1,0 +1,15 @@
+package eu.darken.apl.map.ui.settings
+
+import dagger.hilt.android.lifecycle.HiltViewModel
+import eu.darken.apl.common.coroutine.DispatcherProvider
+import eu.darken.apl.common.debug.logging.logTag
+import eu.darken.apl.common.uix.ViewModel3
+import javax.inject.Inject
+
+@HiltViewModel
+class MapSettingsViewModel @Inject constructor(
+    dispatcherProvider: DispatcherProvider,
+) : ViewModel3(
+    dispatcherProvider,
+    tag = logTag("Settings", "Map", "VM"),
+)

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -168,6 +168,10 @@
     <string name="feeder_notification_snooze_action">Schlummern</string>
 
     <string name="map_page_label">Karte</string>
+    <string name="map_settings_title">Karte</string>
+    <string name="map_settings_summary">Kartenanzeigeeinstellungen</string>
+    <string name="map_settings_restore_last_view_title">Letzte Ansicht wiederherstellen</string>
+    <string name="map_settings_restore_last_view_summary">Letzte Kartenposition und Zoomstufe beim Öffnen der App wiederherstellen</string>
 
     <string name="watch_list_page_label">Merkliste</string>
     <string name="watch_list_add_title">Neue Beobachtung hinzufügen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -178,6 +178,10 @@
     <string name="feeder_notification_snooze_action">Posponer</string>
 
     <string name="map_page_label">Mapa</string>
+    <string name="map_settings_title">Mapa</string>
+    <string name="map_settings_summary">Configuración de visualización del mapa</string>
+    <string name="map_settings_restore_last_view_title">Restaurar última vista</string>
+    <string name="map_settings_restore_last_view_summary">Restaurar la última posición y nivel de zoom del mapa al abrir la aplicación</string>
 
     <string name="watch_list_page_label">Lista de seguimiento</string>
     <string name="watch_list_add_title">Añadir nuevo seguimiento</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -178,6 +178,10 @@
     <string name="feeder_notification_snooze_action">Reporter</string>
 
     <string name="map_page_label">Carte</string>
+    <string name="map_settings_title">Carte</string>
+    <string name="map_settings_summary">Paramètres d\'affichage de la carte</string>
+    <string name="map_settings_restore_last_view_title">Restaurer la dernière vue</string>
+    <string name="map_settings_restore_last_view_summary">Restaurer la dernière position et le niveau de zoom de la carte lors de l\'ouverture de l\'application</string>
 
     <string name="watch_list_page_label">Liste de surveillance</string>
     <string name="watch_list_add_title">Ajouter une nouvelle surveillance</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -178,6 +178,10 @@
     <string name="feeder_notification_snooze_action">Posticipa</string>
 
     <string name="map_page_label">Mappa</string>
+    <string name="map_settings_title">Mappa</string>
+    <string name="map_settings_summary">Impostazioni di visualizzazione della mappa</string>
+    <string name="map_settings_restore_last_view_title">Ripristina ultima vista</string>
+    <string name="map_settings_restore_last_view_summary">Ripristina l\'ultima posizione e livello di zoom della mappa all\'apertura dell\'app</string>
 
     <string name="watch_list_page_label">Lista di osservazione</string>
     <string name="watch_list_add_title">Aggiungi nuova osservazione</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -182,6 +182,10 @@
     <string name="feeder_notification_snooze_action">Отложить</string>
 
     <string name="map_page_label">Карта</string>
+    <string name="map_settings_title">Карта</string>
+    <string name="map_settings_summary">Настройки отображения карты</string>
+    <string name="map_settings_restore_last_view_title">Восстановить последний вид</string>
+    <string name="map_settings_restore_last_view_summary">Восстановить последнюю позицию и уровень масштабирования карты при открытии приложения</string>
 
     <string name="watch_list_page_label">Список наблюдения</string>
     <string name="watch_list_add_title">Добавить новое наблюдение</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -184,6 +184,10 @@
     <string name="feeder_notification_snooze_action">Snooze</string>
 
     <string name="map_page_label">Map</string>
+    <string name="map_settings_title">Map</string>
+    <string name="map_settings_summary">Map display settings</string>
+    <string name="map_settings_restore_last_view_title">Restore last view</string>
+    <string name="map_settings_restore_last_view_summary">Restore the last viewed map position and zoom level when opening the app</string>
 
     <string name="watch_list_page_label">Watchlist</string>
     <string name="watch_list_add_title">Add new watch</string>

--- a/app/src/main/res/xml/preferences_index.xml
+++ b/app/src/main/res/xml/preferences_index.xml
@@ -9,13 +9,20 @@
         app:title="@string/general_settings_label" />
 
     <Preference
+        android:icon="@drawable/ic_map_24"
+        app:fragment="eu.darken.apl.map.ui.settings.MapSettingsFragment"
+        app:summary="@string/map_settings_summary"
+        app:title="@string/map_settings_title" />
+
+    <Preference
         android:icon="@drawable/ic_watchlist_24"
         app:fragment="eu.darken.apl.watch.ui.settings.WatchSettingsFragment"
         app:summary="@string/watch_settings_summary"
         app:title="@string/watch_settings_title" />
+
     <Preference
         android:icon="@drawable/ic_settings_input_antenna_24"
-        app:fragment="eu.darken.apl.watch.ui.settings.WatchSettingsFragment"
+        app:fragment="eu.darken.apl.feeder.ui.settings.FeederSettingsFragment"
         app:summary="@string/feeder_settings_summary"
         app:title="@string/feeder_settings_title" />
 

--- a/app/src/main/res/xml/preferences_map.xml
+++ b/app/src/main/res/xml/preferences_map.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <SwitchPreference
+        android:key="map.restore.last.view.enabled"
+        app:icon="@drawable/ic_crosshairs_gps_24"
+        app:title="@string/map_settings_restore_last_view_title"
+        app:summary="@string/map_settings_restore_last_view_summary" />
+
+</PreferenceScreen>

--- a/app/src/test/java/eu/darken/apl/map/core/MapOptionsTest.kt
+++ b/app/src/test/java/eu/darken/apl/map/core/MapOptionsTest.kt
@@ -1,0 +1,101 @@
+package eu.darken.apl.map.core
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+import org.junit.jupiter.api.Test
+import testhelper.BaseTest
+
+class MapOptionsTest : BaseTest() {
+
+    @Test
+    fun `createUrl includes camera parameters when camera is set`() {
+        val options = MapOptions(
+            camera = MapOptions.Camera(lat = 51.5, lon = -0.12, zoom = 10.0)
+        )
+
+        val url = options.createUrl()
+
+        url shouldContain "lat=51.5"
+        url shouldContain "lon=-0.12"
+        url shouldContain "zoom=10.0"
+    }
+
+    @Test
+    fun `createUrl does not include camera parameters when camera is null`() {
+        val options = MapOptions(camera = null)
+
+        val url = options.createUrl()
+
+        url.contains("lat=") shouldBe false
+        url.contains("lon=") shouldBe false
+        url.contains("zoom=") shouldBe false
+    }
+
+    @Test
+    fun `fromUrl parses camera from valid URL`() {
+        val url = "https://globe.airplanes.live/?lat=52.5&lon=13.4&zoom=8.5"
+
+        val options = MapOptions.fromUrl(url)
+
+        options shouldNotBe null
+        options!!.camera shouldNotBe null
+        options.camera!!.lat shouldBe 52.5
+        options.camera!!.lon shouldBe 13.4
+        options.camera!!.zoom shouldBe 8.5
+    }
+
+    @Test
+    fun `fromUrl returns null for non-globe URL`() {
+        val url = "https://example.com/?lat=52.5&lon=13.4&zoom=8.5"
+
+        val options = MapOptions.fromUrl(url)
+
+        options shouldBe null
+    }
+
+    @Test
+    fun `fromUrl returns options with null camera when URL lacks camera params`() {
+        val url = "https://globe.airplanes.live/?scale=1.1"
+
+        val options = MapOptions.fromUrl(url)
+
+        options shouldNotBe null
+        options!!.camera shouldBe null
+    }
+
+    @Test
+    fun `fromUrl handles partial camera params - returns null camera`() {
+        val url = "https://globe.airplanes.live/?lat=52.5&lon=13.4"
+
+        val options = MapOptions.fromUrl(url)
+
+        options shouldNotBe null
+        options!!.camera shouldBe null  // zoom is missing, so camera should be null
+    }
+
+    @Test
+    fun `Camera data class stores correct values`() {
+        val camera = MapOptions.Camera(lat = 40.7128, lon = -74.006, zoom = 12.0)
+
+        camera.lat shouldBe 40.7128
+        camera.lon shouldBe -74.006
+        camera.zoom shouldBe 12.0
+    }
+
+    @Test
+    fun `createUrl roundtrip - camera survives URL creation and parsing`() {
+        val original = MapOptions(
+            camera = MapOptions.Camera(lat = 48.8566, lon = 2.3522, zoom = 11.0)
+        )
+
+        val url = original.createUrl()
+        val parsed = MapOptions.fromUrl(url)
+
+        parsed shouldNotBe null
+        parsed!!.camera shouldNotBe null
+        parsed.camera!!.lat shouldBe original.camera!!.lat
+        parsed.camera!!.lon shouldBe original.camera!!.lon
+        parsed.camera!!.zoom shouldBe original.camera!!.zoom
+    }
+}

--- a/app/src/test/java/eu/darken/apl/map/core/SavedCameraTest.kt
+++ b/app/src/test/java/eu/darken/apl/map/core/SavedCameraTest.kt
@@ -1,0 +1,107 @@
+package eu.darken.apl.map.core
+
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
+import testhelper.BaseTest
+import testhelper.json.toComparableJson
+
+class SavedCameraTest : BaseTest() {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun `serialization roundtrip preserves values`() {
+        val original = SavedCamera(lat = 51.5074, lon = -0.1278, zoom = 10.5)
+
+        val jsonString = json.encodeToString(SavedCamera.serializer(), original)
+        val restored = json.decodeFromString(SavedCamera.serializer(), jsonString)
+
+        restored shouldBe original
+        restored.lat shouldBe 51.5074
+        restored.lon shouldBe -0.1278
+        restored.zoom shouldBe 10.5
+    }
+
+    @Test
+    fun `serializes to expected JSON format`() {
+        val camera = SavedCamera(lat = 52.52, lon = 13.405, zoom = 8.0)
+
+        val jsonString = json.encodeToString(SavedCamera.serializer(), camera)
+
+        jsonString.toComparableJson() shouldBe """
+            {
+                "lat": 52.52,
+                "lon": 13.405,
+                "zoom": 8.0
+            }
+        """.toComparableJson()
+    }
+
+    @Test
+    fun `deserializes from JSON string`() {
+        val jsonString = """{"lat":48.8566,"lon":2.3522,"zoom":12.0}"""
+
+        val camera = json.decodeFromString(SavedCamera.serializer(), jsonString)
+
+        camera.lat shouldBe 48.8566
+        camera.lon shouldBe 2.3522
+        camera.zoom shouldBe 12.0
+    }
+
+    @Test
+    fun `toCamera converts to MapOptions Camera`() {
+        val savedCamera = SavedCamera(lat = 40.7128, lon = -74.006, zoom = 11.0)
+
+        val camera = savedCamera.toCamera()
+
+        camera.lat shouldBe 40.7128
+        camera.lon shouldBe -74.006
+        camera.zoom shouldBe 11.0
+    }
+
+    @Test
+    fun `from creates SavedCamera from MapOptions Camera`() {
+        val camera = MapOptions.Camera(lat = 35.6762, lon = 139.6503, zoom = 9.0)
+
+        val savedCamera = SavedCamera.from(camera)
+
+        savedCamera.lat shouldBe 35.6762
+        savedCamera.lon shouldBe 139.6503
+        savedCamera.zoom shouldBe 9.0
+    }
+
+    @Test
+    fun `roundtrip through Camera conversion preserves values`() {
+        val original = SavedCamera(lat = -33.8688, lon = 151.2093, zoom = 14.0)
+
+        val camera = original.toCamera()
+        val restored = SavedCamera.from(camera)
+
+        restored shouldBe original
+    }
+
+    @Test
+    fun `handles negative coordinates`() {
+        val camera = SavedCamera(lat = -23.5505, lon = -46.6333, zoom = 7.5)
+
+        val jsonString = json.encodeToString(SavedCamera.serializer(), camera)
+        val restored = json.decodeFromString(SavedCamera.serializer(), jsonString)
+
+        restored.lat shouldBe -23.5505
+        restored.lon shouldBe -46.6333
+        restored.zoom shouldBe 7.5
+    }
+
+    @Test
+    fun `handles high precision decimals`() {
+        val camera = SavedCamera(lat = 51.50735087738341, lon = -0.12775829999999998, zoom = 15.123456789)
+
+        val jsonString = json.encodeToString(SavedCamera.serializer(), camera)
+        val restored = json.decodeFromString(SavedCamera.serializer(), jsonString)
+
+        restored.lat shouldBe 51.50735087738341
+        restored.lon shouldBe -0.12775829999999998
+        restored.zoom shouldBe 15.123456789
+    }
+}


### PR DESCRIPTION
Saves and restores the user's last viewed map position (lat/lon/zoom) when reopening the app. The setting is enabled by default and accessible via Settings > Map.

- Add JavaScript hook for OpenLayers moveend event to capture position
- Store camera as serialized JSON (SavedCamera) instead of full URL
- Add Map settings screen with toggle
- Add translations for DE, ES, FR, IT, RU

Closes #22