### PR TITLE
Feeder: Add picker dialog for multiple local feeders

### DIFF
--- a/app/src/main/java/eu/darken/apl/feeder/ui/add/AddFeederEvents.kt
+++ b/app/src/main/java/eu/darken/apl/feeder/ui/add/AddFeederEvents.kt
@@ -1,11 +1,22 @@
 package eu.darken.apl.feeder.ui.add
 
+import java.util.UUID
+
 sealed class AddFeederEvents {
     object StopCamera : AddFeederEvents()
     data class ShowLocalDetectionResult(val result: LocalDetectionResult) : AddFeederEvents()
+    data class ShowFeederPicker(val feeders: List<DetectedFeeder>) : AddFeederEvents()
 }
 
 enum class LocalDetectionResult {
     FOUND,
     NOT_FOUND
 }
+
+data class DetectedFeeder(
+    val uuid: UUID,
+    val host: String,
+    val label: String?,
+    val latitude: Double?,
+    val longitude: Double?,
+)

--- a/app/src/main/java/eu/darken/apl/feeder/ui/add/AddFeederFragment.kt
+++ b/app/src/main/java/eu/darken/apl/feeder/ui/add/AddFeederFragment.kt
@@ -143,6 +143,7 @@ class AddFeederFragment : Fragment3(R.layout.add_feeder_fragment) {
                     }
                     Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show()
                 }
+                is AddFeederEvents.ShowFeederPicker -> showFeederPickerDialog(event.feeders)
             }
         }
 
@@ -257,6 +258,26 @@ class AddFeederFragment : Fragment3(R.layout.add_feeder_fragment) {
         ui.formContainer.visibility = View.VISIBLE
         ui.buttonContainer.visibility = View.VISIBLE
         cameraPreviewBinding = null
+    }
+
+    private fun showFeederPickerDialog(feeders: List<DetectedFeeder>) {
+        val items = feeders.map { feeder ->
+            val displayName = feeder.label ?: feeder.host
+            val uuidShort = feeder.uuid.toString().take(8)
+            "$displayName ($uuidShort… @ ${feeder.host})"
+        }.toTypedArray()
+
+        var selectedIndex = 0
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle(R.string.feeder_list_multiple_feeders_title)
+            .setSingleChoiceItems(items, selectedIndex) { _, which ->
+                selectedIndex = which
+            }
+            .setPositiveButton(R.string.common_done_action) { _, _ ->
+                vm.selectDetectedFeeder(feeders[selectedIndex])
+            }
+            .setNegativeButton(R.string.common_cancel_action, null)
+            .show()
     }
 
     @ExperimentalGetImage

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -135,9 +135,10 @@
     <string name="feeder_list_local_detection_title">Local Detection</string>
     <string name="feeder_list_local_detection_description">Detect feeders running on the same network</string>
     <string name="feeder_list_detect_local_title">Detect Local Feeder</string>
-    <string name="feeder_list_detecting_local_feeder">Detecting local feeder...</string>
+    <string name="feeder_list_detecting_local_feeder">Detecting local feeder…</string>
     <string name="feeder_list_no_local_feeder_found">No local feeder found</string>
     <string name="feeder_list_local_feeder_found">Local feeder detected and fields filled</string>
+    <string name="feeder_list_multiple_feeders_title">Multiple Feeders Detected</string>
 
     <string name="feeder_list_camera_permission_required_title">Camera Permission Required</string>
     <string name="feeder_list_camera_permission_required_message">Camera permission is required to scan QR codes.</string>


### PR DESCRIPTION
## Summary
- Show a picker dialog when local detection finds multiple feeders on the network
- Display each feeder with label (or host IP), truncated UUID, and IP address
- Previously would silently use the first detected feeder

## Test plan
- [x] Test with single local feeder (should auto-fill as before)
- [x] Test with multiple local feeders (should show picker dialog)
- [x] Test with no local feeders (should show "not found" message)