### PR TITLE
Feeder: Handle null UUID in mlat_clients API response

### DIFF
--- a/app/src/main/java/eu/darken/apl/feeder/core/api/FeedStatus.kt
+++ b/app/src/main/java/eu/darken/apl/feeder/core/api/FeedStatus.kt
@@ -20,7 +20,7 @@ data class FeedStatus(
     @Serializable
     data class MlatClient(
         @SerialName("user") val user: String,
-        @Contextual @SerialName("uuid") val uuid: UUID,
+        @Contextual @SerialName("uuid") val uuid: UUID?,
         @SerialName("lat") val latitude: Double,
         @SerialName("lon") val longitude: Double,
     )


### PR DESCRIPTION
## Summary
- Fix crash when API returns `"uuid": null` in `mlat_clients` response
- Make `FeedStatus.MlatClient.uuid` nullable to handle this edge case

## Test plan
- [x] Build succeeds: `./gradlew :app:compileFossDebugKotlin --no-daemon`
- [x] Verify local feeder detection works when API returns null UUID in mlat_clients