### PR TITLE
Build: Simplify unit test CI to debug builds only

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        variant: [ Debug,Beta,Release ]
+        variant: [ Debug ]
         flavor: [ testFoss,testGplay ]
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
## Summary
- Reduce test-modules CI matrix from 6 combinations to 2
- Run unit tests only for Debug variant (Foss + Gplay)
- Beta and Release variants don't need separate test runs since tests are identical

## Test plan
- [ ] Verify CI workflow passes on this PR