### PR TITLE
Common: Remove stale TODO comments

### DIFF
--- a/app/src/main/java/eu/darken/apl/common/navigation/NavArgsExtensions.kt
+++ b/app/src/main/java/eu/darken/apl/common/navigation/NavArgsExtensions.kt
@@ -7,7 +7,6 @@ import androidx.navigation.NavArgs
 import androidx.navigation.NavArgsLazy
 import java.io.Serializable
 
-// TODO Remove with "androidx.navigation:navigation-safe-args-gradle-plugin:2.4.0-alpha/stable"
 inline fun <reified Args : NavArgs> SavedStateHandle.navArgs() = NavArgsLazy(Args::class) {
     Bundle().apply {
         keys().forEach {

--- a/app/src/main/java/eu/darken/apl/watch/core/WatchRepo.kt
+++ b/app/src/main/java/eu/darken/apl/watch/core/WatchRepo.kt
@@ -90,7 +90,7 @@ class WatchRepo @Inject constructor(
         .replayingShare(appScope)
 
     suspend fun refresh() {
-        log(TAG) { "refresh()" } // TODO
+        log(TAG) { "refresh()" }
         refreshTrigger.value = UUID.randomUUID()
     }
 

--- a/app/src/main/java/eu/darken/apl/watch/core/alerts/WatchWorker.kt
+++ b/app/src/main/java/eu/darken/apl/watch/core/alerts/WatchWorker.kt
@@ -66,8 +66,7 @@ class WatchWorker @AssistedInject constructor(
         try {
             withTimeout(60 * 1000) {
                 try {
-                    val newAlerts = watchMonitor.check()
-                    // TODO for each new alert show a notification
+                    watchMonitor.check()
                 } catch (e: Exception) {
                     log(TAG, ERROR) { "Failed to refresh ${e.asLog()}" }
                 }


### PR DESCRIPTION
## Summary
- Remove obsolete TODO in NavArgsExtensions.kt (the workaround is still needed as Safe Args 2.9.6 doesn't provide a built-in SavedStateHandle.navArgs() extension)
- Remove completed TODO in WatchWorker.kt (notifications are implemented in WatchMonitor.check())
- Remove trailing TODO in WatchRepo.kt (implementation is complete)

## Test plan
- [x] Build passes: `./gradlew :app:compileFossDebugKotlin`