### PR TITLE
Search: Batch airframe API requests using comma-separated values

### DIFF
--- a/app/src/main/java/eu/darken/apl/main/core/api/AirplanesLiveEndpoint.kt
+++ b/app/src/main/java/eu/darken/apl/main/core/api/AirplanesLiveEndpoint.kt
@@ -88,13 +88,13 @@ class AirplanesLiveEndpoint @Inject constructor(
     suspend fun getByAirframe(
         airframes: Set<Airframe>
     ): Collection<AirplanesLiveApi.Aircraft> = withContext(dispatcherProvider.IO) {
-        log(TAG) { "getByAirframe(squawks=$airframes)" }
+        log(TAG) { "getByAirframe(airframes=$airframes)" }
         if (airframes.isEmpty()) return@withContext emptySet()
         airframes
+            .chunkToCommaArgs(limit = 1000)
             .map { api.getAircraftByAirframe(it).throwForErrors() }
             .toList()
-            .map { it.ac }
-            .flatten()
+            .flatMap { it.ac }
     }
 
     suspend fun getMilitary(): Collection<AirplanesLiveApi.Aircraft> = withContext(dispatcherProvider.IO) {


### PR DESCRIPTION
## Summary
- Modify `getByAirframe` to use `chunkToCommaArgs()` for batching multiple airframe types into comma-separated API requests
- This matches the existing pattern used by `getByHex`, `getByCallsign`, and `getByRegistration`
- Reduces API calls when searching for multiple aircraft types

## Changes
- Use `.chunkToCommaArgs(limit = 1000)` to batch airframe requests
- Fix log message typo ("squawks" → "airframes")
- Use `.flatMap` for consistency with other batched methods