### PR TITLE
Common: Fix AirplanesLiveEndpointTest CI failures with MockWebServer

### DIFF
--- a/app/src/main/java/eu/darken/apl/main/core/api/AirplanesLiveEndpoint.kt
+++ b/app/src/main/java/eu/darken/apl/main/core/api/AirplanesLiveEndpoint.kt
@@ -23,15 +23,12 @@ class AirplanesLiveEndpoint @Inject constructor(
     private val jsonConverterFactory: Converter.Factory,
     private val dispatcherProvider: DispatcherProvider,
 ) {
+    internal var baseUrl: String = "https://api.airplanes.live/v2/"
 
     private val api: AirplanesLiveApi by lazy {
-        val configHttpClient = baseClient.newBuilder().apply {
-
-        }.build()
-
         Retrofit.Builder()
-            .client(configHttpClient)
-            .baseUrl("https://api.airplanes.live/v2/")
+            .client(baseClient.newBuilder().build())
+            .baseUrl(baseUrl)
             .addConverterFactory(jsonConverterFactory)
             .build()
             .create(AirplanesLiveApi::class.java)

--- a/app/src/test/java/eu/darken/apl/main/core/api/AirplanesLiveEndpointTest.kt
+++ b/app/src/test/java/eu/darken/apl/main/core/api/AirplanesLiveEndpointTest.kt
@@ -2,64 +2,101 @@ package eu.darken.apl.main.core.api
 
 import eu.darken.apl.common.http.HttpModule
 import eu.darken.apl.common.serialization.SerializationModule
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import kotlinx.coroutines.test.runTest
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelper.BaseTest
 import testhelper.coroutine.TestDispatcherProvider
 
 class AirplanesLiveEndpointTest : BaseTest() {
+    private lateinit var mockWebServer: MockWebServer
     private lateinit var endpoint: AirplanesLiveEndpoint
+
+    private val mockResponse = """{"ac":[],"total":0,"msg":"No error","now":1234567890,"ctime":1234567890,"ptime":0}"""
 
     @BeforeEach
     fun setup() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start()
+
         endpoint = AirplanesLiveEndpoint(
             baseClient = HttpModule().baseHttpClient(),
             dispatcherProvider = TestDispatcherProvider(),
-            jsonConverterFactory = HttpModule().jsonConverter(SerializationModule().json())
-        )
+            jsonConverterFactory = HttpModule().jsonConverter(SerializationModule().json()),
+        ).apply {
+            baseUrl = mockWebServer.url("/").toString()
+        }
+    }
+
+    @AfterEach
+    fun teardown() {
+        mockWebServer.shutdown()
     }
 
     @Test
     fun `aircraft by squawks`() = runTest {
-        endpoint.getBySquawk(setOf("3532,1200,0420")).apply {
+        mockWebServer.enqueue(MockResponse().setBody(mockResponse))
+        mockWebServer.enqueue(MockResponse().setBody(mockResponse))
+        mockWebServer.enqueue(MockResponse().setBody(mockResponse))
+
+        endpoint.getBySquawk(setOf("3532", "1200", "0420")).apply {
             this shouldNotBe null
+            this.size shouldBe 0
         }
     }
 
     @Test
-    fun `aircraft by hexes `() = runTest {
+    fun `aircraft by hexes`() = runTest {
+        mockWebServer.enqueue(MockResponse().setBody(mockResponse))
+
         endpoint.getByHex(setOf("A213BD,A4FBAC")).apply {
             this shouldNotBe null
+            this.size shouldBe 0
         }
     }
 
     @Test
     fun `aircraft by callsigns`() = runTest {
+        mockWebServer.enqueue(MockResponse().setBody(mockResponse))
+
         endpoint.getByCallsign(setOf("AAL1002,AAL1328")).apply {
             this shouldNotBe null
+            this.size shouldBe 0
         }
     }
 
     @Test
     fun `aircraft by registration`() = runTest {
+        mockWebServer.enqueue(MockResponse().setBody(mockResponse))
+
         endpoint.getByRegistration(setOf("N656NK")).apply {
             this shouldNotBe null
+            this.size shouldBe 0
         }
     }
 
     @Test
     fun `aircraft by airframe`() = runTest {
+        mockWebServer.enqueue(MockResponse().setBody(mockResponse))
+
         endpoint.getByAirframe(setOf("F16")).apply {
             this shouldNotBe null
+            this.size shouldBe 0
         }
     }
 
     @Test
     fun `aircraft by location`() = runTest {
+        mockWebServer.enqueue(MockResponse().setBody(mockResponse))
+
         endpoint.getByLocation(51.473419, -0.491683, 100).apply {
             this shouldNotBe null
+            this.size shouldBe 0
         }
     }
 }


### PR DESCRIPTION
## Summary
- Convert `AirplanesLiveEndpointTest` from real HTTP calls to MockWebServer
- Prevents CI failures caused by rate limiting or network issues

## Test plan
- [x] All unit tests pass locally: `./gradlew testFossDebugUnitTest`