### PR TITLE
Build: Harden GitHub Actions workflow permissions

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   lint-vital:
     name: Lint vitals
@@ -19,6 +22,8 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup project and build environment
         uses: ./.github/actions/common-setup
 
@@ -37,6 +42,8 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup project and build environment
         uses: ./.github/actions/common-setup
 
@@ -54,6 +61,8 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup project and build environment
         uses: ./.github/actions/common-setup
 

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -8,10 +8,15 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   validation:
     name: "Validation"
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          persist-credentials: false
       - uses: gradle/actions/wrapper-validation@0723195856401067f7a2779048b490ace7a47d7c #v5.0.2

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -11,6 +11,9 @@ on:
         type: boolean
         default: true
 
+permissions:
+  contents: read
+
 jobs:
   release-github:
     name: Create GitHub release
@@ -33,6 +36,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup project and build environment
         uses: ./.github/actions/common-setup


### PR DESCRIPTION
## Summary
- Add explicit `permissions: contents: read` to all three workflows — previously they inherited the repo default (read+write on all scopes)
- Set `persist-credentials: false` on all `actions/checkout` steps — no workflow needs git credentials after checkout
- The release workflow's job-level `permissions: contents: write` is preserved for creating GitHub releases

## Why
Without an explicit `permissions` block, `GITHUB_TOKEN` gets read+write access to all scopes (contents, packages, issues, pull-requests, deployments). CI workflows that only build and test should not have write access. Similarly, `actions/checkout` persists credentials in `.git/config` by default, leaving them accessible to all subsequent steps in the job.