### PR TITLE
Common: Fix aircraft photos not loading

### DIFF
--- a/app/src/main/java/eu/darken/apl/common/http/HttpModule.kt
+++ b/app/src/main/java/eu/darken/apl/common/http/HttpModule.kt
@@ -56,7 +56,8 @@ class HttpModule {
     @Reusable
     @Provides
     fun userAgent(): String =
-        "${BuildConfigWrap.APPLICATION_ID}/${BuildConfigWrap.VERSION_NAME} (Android ${Build.VERSION.RELEASE}; ${Build.MODEL})"
+        "${BuildConfigWrap.APPLICATION_ID}/${BuildConfigWrap.VERSION_NAME} " +
+            "(Android ${Build.VERSION.RELEASE}; ${Build.MODEL}; +https://github.com/d4rken-org/airplanes-live-app)"
 
     @Singleton
     @Provides

--- a/app/src/test/java/eu/darken/apl/common/http/HttpModuleTest.kt
+++ b/app/src/test/java/eu/darken/apl/common/http/HttpModuleTest.kt
@@ -2,6 +2,7 @@ package eu.darken.apl.common.http
 
 import eu.darken.apl.common.BuildConfigWrap
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.AfterEach
@@ -30,8 +31,15 @@ class HttpModuleTest : BaseTest() {
     @Test
     fun `userAgent returns correct user-agent string`() {
         val expectedUserAgent =
-            "${BuildConfigWrap.APPLICATION_ID}/${BuildConfigWrap.VERSION_NAME} (Android null; null)"
+            "${BuildConfigWrap.APPLICATION_ID}/${BuildConfigWrap.VERSION_NAME} " +
+                "(Android null; null; +https://github.com/d4rken-org/airplanes-live-app)"
         httpModule.userAgent() shouldBe expectedUserAgent
+    }
+
+    @Test
+    fun `userAgent includes a contact url`() {
+        // planespotters.net returns HTTP 403 unless the User-Agent carries a contact URL or email
+        httpModule.userAgent() shouldContain "+https://github.com/d4rken-org/airplanes-live-app"
     }
 
     @Test


### PR DESCRIPTION
Aircraft photos stopped loading because the Planespotters photo API now rejects requests whose User-Agent has no contact URL or email, responding with HTTP 403.

- Added the project's repository URL as a contact token to the app's User-Agent, satisfying the API's requirement.
- Applied at the shared HTTP-client layer so every API request carries it.
- Updated and added unit tests asserting the User-Agent includes the contact URL.

Closes #124
