### PR TITLE
Map: Fix map not resizing when toggling fullscreen

### DIFF
--- a/app/src/main/java/eu/darken/apl/map/core/MapHandler.kt
+++ b/app/src/main/java/eu/darken/apl/map/core/MapHandler.kt
@@ -178,23 +178,8 @@ class MapHandler @AssistedInject constructor(
         }
 
         // The globe page uses CSS height:100% which doesn't resolve in Compose-hosted WebViews.
-        // Force explicit pixel heights and trigger a resize so OpenLayers re-initializes.
-        view.evaluateJavascript(
-            """
-            (function() {
-                var h = window.innerHeight + 'px';
-                document.documentElement.style.setProperty('height', h, 'important');
-                document.body.style.setProperty('height', h, 'important');
-                var lc = document.getElementById('layout_container');
-                if (lc) lc.style.setProperty('height', h, 'important');
-                var mc = document.getElementById('map_container');
-                if (mc) mc.style.setProperty('height', h, 'important');
-                requestAnimationFrame(function() {
-                    window.dispatchEvent(new Event('resize'));
-                });
-            })();
-        """.trimIndent(), null
-        )
+        // Pin explicit pixel heights and keep them in sync as the viewport changes (e.g. fullscreen).
+        view.syncViewportHeight()
 
         // Set localStorage on correct origin and switch layer via OL API
         view.ensureMapLayer(mapLayerKey)

--- a/app/src/main/java/eu/darken/apl/map/core/MapHooks.kt
+++ b/app/src/main/java/eu/darken/apl/map/core/MapHooks.kt
@@ -635,3 +635,37 @@ internal fun WebView.showHoverInfo() {
     """.trimIndent()
     evaluateJavascript(jsCode, null)
 }
+
+internal fun WebView.syncViewportHeight() {
+    log(MapHandler.TAG) { "syncViewportHeight()" }
+    val jsCode = """
+        (function() {
+            if (!window._aplSyncViewport) {
+                window._aplSyncViewport = function() {
+                    var h = window.innerHeight;
+                    if (!h) return;
+                    var px = h + 'px';
+                    document.documentElement.style.setProperty('height', px, 'important');
+                    if (document.body) document.body.style.setProperty('height', px, 'important');
+                    var lc = document.getElementById('layout_container');
+                    if (lc) lc.style.setProperty('height', px, 'important');
+                    var mc = document.getElementById('map_container');
+                    if (mc) mc.style.setProperty('height', px, 'important');
+                    var olSize = 'n/a';
+                    try {
+                        if (typeof OLMap !== 'undefined' && typeof OLMap.getSize === 'function') {
+                            olSize = OLMap.getSize();
+                        }
+                    } catch(e) { /* OLMap not ready */ }
+                    console.log('apl viewport sync h=' + h + ' olSize=' + olSize);
+                };
+                window.addEventListener('resize', window._aplSyncViewport);
+            }
+            window._aplSyncViewport();
+            requestAnimationFrame(function() {
+                window.dispatchEvent(new Event('resize'));
+            });
+        })();
+    """.trimIndent()
+    evaluateJavascript(jsCode, null)
+}

--- a/app/src/main/java/eu/darken/apl/map/ui/MapScreen.kt
+++ b/app/src/main/java/eu/darken/apl/map/ui/MapScreen.kt
@@ -15,10 +15,13 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -339,7 +342,18 @@ fun MapScreenHost(
             }
         },
         containerColor = MaterialTheme.colorScheme.background,
-        contentWindowInsets = aplContentWindowInsets(hasBottomNav = !isFullscreen),
+        contentWindowInsets = when {
+            !isFullscreen -> aplContentWindowInsets(hasBottomNav = true)
+            // Pre-R the immersive block above can't hide the system bars, so keep their inset
+            android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.R ->
+                aplContentWindowInsets(hasBottomNav = false)
+            // tar1090 draws its own controls inside the WebView and Compose can't inset those,
+            // so keep the cutout reserved while the native panel is off
+            !useNativePanel -> WindowInsets.displayCutout
+            // Bars are hidden: the map extends under any display cutout, the Compose overlays
+            // are inset separately so they stay clear of it
+            else -> WindowInsets(0, 0, 0, 0)
+        },
     ) { contentPadding ->
         Column(
             modifier = Modifier
@@ -351,6 +365,18 @@ fun MapScreenHost(
                 targetValue = if (sheetState.currentValue == SheetValue.Expanded) 0.dp else 28.dp,
                 label = "sheetCornerRadius",
             )
+
+            // Must match the Scaffold branch above that drops the inset: only in that exact
+            // state do the Compose overlays have to re-apply the cutout themselves
+            val cutoutSafe = if (
+                isFullscreen &&
+                useNativePanel &&
+                android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R
+            ) {
+                Modifier.windowInsetsPadding(WindowInsets.displayCutout)
+            } else {
+                Modifier
+            }
 
             // Map content with bottom sheet
             BottomSheetScaffold(
@@ -373,6 +399,7 @@ fun MapScreenHost(
                             onShowInSearch = vm::showInSearch,
                             onAddWatch = vm::addWatch,
                             onThumbnailClick = vm::onOpenUrl,
+                            modifier = if (sheetState.currentValue == SheetValue.Expanded) cutoutSafe else Modifier,
                         )
                     }
                 },
@@ -383,182 +410,185 @@ fun MapScreenHost(
                 modifier = Modifier.weight(1f),
             ) { _ ->
                 Box(modifier = Modifier.fillMaxSize()) {
-                val lifecycleOwner = LocalLifecycleOwner.current
+                    val lifecycleOwner = LocalLifecycleOwner.current
 
-                AndroidView(
-                    factory = { ctx ->
-                        WebView(ctx).also { webView ->
-                            webViewRef = webView
-                            val uiConfig = MapUiConfig(useNativePanel = vm.useNativePanel.value, showHoverInfo = vm.showHoverInfo.value)
-                            val handler = mapHandlerFactory.create(webView, uiConfig, vm.mapLayer.value, enabledOverlays ?: emptySet())
-                            mapHandlerRef = handler
+                    AndroidView(
+                        factory = { ctx ->
+                            WebView(ctx).also { webView ->
+                                webViewRef = webView
+                                val uiConfig = MapUiConfig(useNativePanel = vm.useNativePanel.value, showHoverInfo = vm.showHoverInfo.value)
+                                val handler = mapHandlerFactory.create(webView, uiConfig, vm.mapLayer.value, enabledOverlays ?: emptySet())
+                                mapHandlerRef = handler
 
-                            scope.launch {
-                                handler.events
-                                    .onEach { event ->
-                                        when (event) {
-                                            is MapHandler.Event.OpenUrl -> vm.onOpenUrl(event.url)
-                                            is MapHandler.Event.OptionsChanged -> vm.onOptionsUpdated(event.options)
-                                            is MapHandler.Event.AircraftDetailsChanged -> vm.onAircraftDetailsChanged(event.details)
-                                            MapHandler.Event.AircraftDeselected -> vm.onAircraftDeselected()
-                                            is MapHandler.Event.ButtonStatesChanged -> vm.onButtonStatesChanged(event.jsonData)
-                                            is MapHandler.Event.AircraftListChanged -> vm.onAircraftListChanged(event.data)
+                                scope.launch {
+                                    handler.events
+                                        .onEach { event ->
+                                            when (event) {
+                                                is MapHandler.Event.OpenUrl -> vm.onOpenUrl(event.url)
+                                                is MapHandler.Event.OptionsChanged -> vm.onOptionsUpdated(event.options)
+                                                is MapHandler.Event.AircraftDetailsChanged -> vm.onAircraftDetailsChanged(event.details)
+                                                MapHandler.Event.AircraftDeselected -> vm.onAircraftDeselected()
+                                                is MapHandler.Event.ButtonStatesChanged -> vm.onButtonStatesChanged(event.jsonData)
+                                                is MapHandler.Event.AircraftListChanged -> vm.onAircraftListChanged(event.data)
+                                            }
                                         }
-                                    }
-                                    .launchIn(this)
+                                        .launchIn(this)
+                                }
+
+                                // Wait for Compose layout so WebView has non-zero dimensions for the globe page
+                                webView.doOnLayout { handler.loadMap(currentState.options) }
                             }
+                        },
+                        update = { _ ->
+                            // Skip before initial load completes (deferred via post above)
+                            if (webViewRef?.url != null) {
+                                mapHandlerRef?.loadMap(currentState.options)
+                            }
+                        },
+                        modifier = Modifier.fillMaxSize(),
+                    )
 
-                            // Wait for Compose layout so WebView has non-zero dimensions for the globe page
-                            webView.doOnLayout { handler.loadMap(currentState.options) }
+                    // WebView lifecycle management
+                    DisposableEffect(lifecycleOwner) {
+                        val observer = LifecycleEventObserver { _, event ->
+                            when (event) {
+                                Lifecycle.Event.ON_RESUME -> webViewRef?.onResume()
+                                Lifecycle.Event.ON_PAUSE -> webViewRef?.onPause()
+                                else -> {}
+                            }
                         }
-                    },
-                    update = { _ ->
-                        // Skip before initial load completes (deferred via post above)
-                        if (webViewRef?.url != null) {
-                            mapHandlerRef?.loadMap(currentState.options)
-                        }
-                    },
-                    modifier = Modifier.fillMaxSize(),
-                )
-
-                // WebView lifecycle management
-                DisposableEffect(lifecycleOwner) {
-                    val observer = LifecycleEventObserver { _, event ->
-                        when (event) {
-                            Lifecycle.Event.ON_RESUME -> webViewRef?.onResume()
-                            Lifecycle.Event.ON_PAUSE -> webViewRef?.onPause()
-                            else -> {}
+                        lifecycleOwner.lifecycle.addObserver(observer)
+                        onDispose {
+                            lifecycleOwner.lifecycle.removeObserver(observer)
                         }
                     }
-                    lifecycleOwner.lifecycle.addObserver(observer)
-                    onDispose {
-                        lifecycleOwner.lifecycle.removeObserver(observer)
-                    }
-                }
 
-                // Fullscreen toggle + My Location buttons
-                Column(
-                    modifier = Modifier
-                        .align(Alignment.TopStart)
-                        .padding(16.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    FilledTonalIconButton(
-                        onClick = { isFullscreen = !isFullscreen },
-                        modifier = Modifier.size(48.dp),
-                    ) {
-                        Icon(
-                            if (isFullscreen) Icons.TwoTone.FullscreenExit else Icons.TwoTone.Fullscreen,
-                            contentDescription = stringResource(R.string.common_fullscreen_action),
-                        )
-                    }
-
-                    if (isFullscreen) {
-                        FilledTonalIconButton(
-                            onClick = { vm.goToMyLocation() },
-                            modifier = Modifier.size(48.dp),
+                    Box(modifier = Modifier.fillMaxSize().then(cutoutSafe)) {
+                        // Fullscreen toggle + My Location buttons
+                        Column(
+                            modifier = Modifier
+                                .align(Alignment.TopStart)
+                                .padding(16.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
                         ) {
-                            Icon(
-                                Icons.TwoTone.MyLocation,
-                                contentDescription = stringResource(R.string.map_my_location_action),
-                            )
-                        }
-                    }
-
-                    if (vm.hasRotationSensor) {
-                        FilledTonalIconButton(
-                            onClick = { vm.goToAr() },
-                            modifier = Modifier.size(48.dp),
-                        ) {
-                            Icon(
-                                imageVector = Icons.TwoTone.ViewInAr,
-                                contentDescription = stringResource(R.string.ar_view_action),
-                            )
-                        }
-                    }
-                }
-
-                // Map controls + sidebar toggle
-                Column(
-                    modifier = Modifier
-                        .align(Alignment.TopEnd)
-                        .padding(16.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    // Controls button + dropdown
-                    Box {
-                        FilledTonalIconButton(
-                            onClick = { controlsExpanded = true },
-                            modifier = Modifier.size(48.dp),
-                        ) {
-                            Icon(
-                                Icons.TwoTone.Tune,
-                                contentDescription = stringResource(R.string.map_controls_action),
-                            )
-                        }
-
-                        DropdownMenu(
-                            expanded = controlsExpanded,
-                            onDismissRequest = { controlsExpanded = false },
-                        ) {
-                            MapControl.entries.forEach { control ->
-                                val isActive = buttonStates[control.buttonId] == true
-                                val needsSelection = control.requiresSelection && aircraftDetails == null
-
-                                DropdownMenuItem(
-                                    text = { Text(stringResource(control.labelRes)) },
-                                    onClick = {
-                                        when (control.type) {
-                                            MapControl.ControlType.ACTION -> {
-                                                mapHandlerRef?.executeToggle(control.buttonId)
-                                                controlsExpanded = false
-                                            }
-
-                                            MapControl.ControlType.TOGGLE -> {
-                                                mapHandlerRef?.executeToggle(control.buttonId)
-                                            }
-                                        }
-                                    },
-                                    leadingIcon = if (control.type == MapControl.ControlType.TOGGLE && isActive) {
-                                        {
-                                            Icon(
-                                                Icons.TwoTone.Check,
-                                                contentDescription = null,
-                                            )
-                                        }
-                                    } else {
-                                        null
-                                    },
-                                    enabled = !needsSelection,
+                            FilledTonalIconButton(
+                                onClick = { isFullscreen = !isFullscreen },
+                                modifier = Modifier.size(48.dp),
+                            ) {
+                                Icon(
+                                    if (isFullscreen) Icons.TwoTone.FullscreenExit else Icons.TwoTone.Fullscreen,
+                                    contentDescription = stringResource(R.string.common_fullscreen_action),
                                 )
                             }
-                        }
-                    }
 
-                    // Sidebar toggle button (only when native panel enabled)
-                    if (useNativePanel) {
-                        FilledTonalIconButton(
-                            onClick = { vm.toggleSidebar() },
-                            modifier = Modifier.size(48.dp),
+                            if (isFullscreen) {
+                                FilledTonalIconButton(
+                                    onClick = { vm.goToMyLocation() },
+                                    modifier = Modifier.size(48.dp),
+                                ) {
+                                    Icon(
+                                        Icons.TwoTone.MyLocation,
+                                        contentDescription = stringResource(R.string.map_my_location_action),
+                                    )
+                                }
+                            }
+
+                            if (vm.hasRotationSensor) {
+                                FilledTonalIconButton(
+                                    onClick = { vm.goToAr() },
+                                    modifier = Modifier.size(48.dp),
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.TwoTone.ViewInAr,
+                                        contentDescription = stringResource(R.string.ar_view_action),
+                                    )
+                                }
+                            }
+                        }
+
+                        // Map controls + sidebar toggle
+                        Column(
+                            modifier = Modifier
+                                .align(Alignment.TopEnd)
+                                .padding(16.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
                         ) {
-                            Icon(
-                                Icons.AutoMirrored.TwoTone.ViewSidebar,
-                                contentDescription = stringResource(R.string.map_sidebar_toggle_action),
-                            )
+                            // Controls button + dropdown
+                            Box {
+                                FilledTonalIconButton(
+                                    onClick = { controlsExpanded = true },
+                                    modifier = Modifier.size(48.dp),
+                                ) {
+                                    Icon(
+                                        Icons.TwoTone.Tune,
+                                        contentDescription = stringResource(R.string.map_controls_action),
+                                    )
+                                }
+
+                                DropdownMenu(
+                                    expanded = controlsExpanded,
+                                    onDismissRequest = { controlsExpanded = false },
+                                ) {
+                                    MapControl.entries.forEach { control ->
+                                        val isActive = buttonStates[control.buttonId] == true
+                                        val needsSelection = control.requiresSelection && aircraftDetails == null
+
+                                        DropdownMenuItem(
+                                            text = { Text(stringResource(control.labelRes)) },
+                                            onClick = {
+                                                when (control.type) {
+                                                    MapControl.ControlType.ACTION -> {
+                                                        mapHandlerRef?.executeToggle(control.buttonId)
+                                                        controlsExpanded = false
+                                                    }
+
+                                                    MapControl.ControlType.TOGGLE -> {
+                                                        mapHandlerRef?.executeToggle(control.buttonId)
+                                                    }
+                                                }
+                                            },
+                                            leadingIcon = if (control.type == MapControl.ControlType.TOGGLE && isActive) {
+                                                {
+                                                    Icon(
+                                                        Icons.TwoTone.Check,
+                                                        contentDescription = null,
+                                                    )
+                                                }
+                                            } else {
+                                                null
+                                            },
+                                            enabled = !needsSelection,
+                                        )
+                                    }
+                                }
+                            }
+
+                            // Sidebar toggle button (only when native panel enabled)
+                            if (useNativePanel) {
+                                FilledTonalIconButton(
+                                    onClick = { vm.toggleSidebar() },
+                                    modifier = Modifier.size(48.dp),
+                                ) {
+                                    Icon(
+                                        Icons.AutoMirrored.TwoTone.ViewSidebar,
+                                        contentDescription = stringResource(R.string.map_sidebar_toggle_action),
+                                    )
+                                }
+                            }
                         }
                     }
-                }
 
-                // Sidebar overlay
-                MapSidebar(
-                    visible = isSidebarOpen && useNativePanel,
-                    sidebarData = sidebarData,
-                    activeSort = sidebarSort,
-                    sortAscending = sidebarSortAscending,
-                    onSortToggle = { vm.toggleSort(it) },
-                    onClose = { vm.closeSidebar() },
-                    onAircraftClick = { hex -> vm.selectAircraftOnMap(hex) },
-                )
+                    // Sidebar overlay
+                    MapSidebar(
+                        visible = isSidebarOpen && useNativePanel,
+                        sidebarData = sidebarData,
+                        activeSort = sidebarSort,
+                        sortAscending = sidebarSortAscending,
+                        onSortToggle = { vm.toggleSort(it) },
+                        onClose = { vm.closeSidebar() },
+                        onAircraftClick = { hex -> vm.selectAircraftOnMap(hex) },
+                        panelModifier = cutoutSafe,
+                    )
                 }
             }
 
@@ -590,9 +620,10 @@ private fun AircraftDetailsSheetContent(
     onShowInSearch: (String) -> Unit,
     onAddWatch: (String) -> Unit,
     onThumbnailClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     LazyColumn(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         contentPadding = PaddingValues(bottom = 32.dp),
     ) {
         // Peek content — strict layout within ~200dp peek height

--- a/app/src/main/java/eu/darken/apl/map/ui/MapSidebar.kt
+++ b/app/src/main/java/eu/darken/apl/map/ui/MapSidebar.kt
@@ -65,6 +65,9 @@ fun MapSidebar(
     onClose: () -> Unit,
     onAircraftClick: (String) -> Unit,
     modifier: Modifier = Modifier,
+    // The scrim must stay full-screen to catch all dismiss taps, so display-cutout insets
+    // supplied by the caller are applied to the sliding panel only.
+    panelModifier: Modifier = Modifier,
 ) {
     AnimatedVisibility(
         visible = visible,
@@ -89,7 +92,9 @@ fun MapSidebar(
                 onSortToggle = onSortToggle,
                 onClose = onClose,
                 onAircraftClick = onAircraftClick,
-                modifier = Modifier.align(Alignment.CenterEnd),
+                modifier = Modifier
+                    .align(Alignment.CenterEnd)
+                    .then(panelModifier),
             )
         }
     }


### PR DESCRIPTION
Toggling fullscreen after the map had finished loading left the map at its previous size. Toggling it *before* the page finished loading worked, which was the clue.

Closes #130

## What was wrong

`MapHandler.onPageFinished` works around CSS `height: 100%` not resolving in Compose-hosted WebViews by reading `window.innerHeight` and pinning it as an `!important` pixel height onto `html`, `body`, `#layout_container` and `#map_container`. That snapshot was taken once and never recomputed, so when the fullscreen toggle grew the WebView the page stayed frozen at the old height.

## Changes

- **`MapHooks.kt`** — new `WebView.syncViewportHeight()` installs a `window` resize listener that re-applies the same pinning whenever the viewport changes. `MapHandler` calls it instead of the old inline block; page-load behaviour is unchanged.
- **`MapScreen.kt`** — fullscreen previously still reserved a top system-bar inset, so the map never reached the top edge. It now runs edge to edge, including under a display cutout, while the floating controls, the aircraft list and the expanded aircraft details are inset so they stay clear of the cutout. Devices that cannot hide their system bars (pre-API 30, where the immersive path is a no-op) keep that space, and the cutout stays reserved while the web interface draws its own controls, since those can't be repositioned from Compose.
- **`MapSidebar.kt`** — new `panelModifier` so the cutout inset applies to the sliding panel only; the dismiss scrim stays full-screen.

Most of the `MapScreen.kt` line count is re-indentation from nesting the overlays — `git diff -w` reduces it to a handful of lines.

## Notes

No explicit `OLMap.updateSize()` call is needed: the site ships OpenLayers 10.7.0, whose `Map` installs a `ResizeObserver` that re-measures when the container box changes. Verified on device — the logged OpenLayers size tracks each viewport change.

No unit test: this is WebView/Blink runtime behaviour and the suite is JVM-only.

## Verification

Emulator, API 36, 1080x2400 with a 128 px top cutout, against the live map:

- Bottom dark band on entering fullscreen: **440 px → 9 px**. Fullscreen CSS viewport **698 → 915 px**, i.e. the full 2400 px screen.
- Entering fullscreen fires two resize events (bar removal, then the inset change); both handled, values converge with no drift across repeated toggling.
- Sidebar dim covers the full screen and dismisses from the top strip; expanded aircraft sheet's copy/close row sits clear of the cutout; windowed layout byte-identical to before the change.
