### PR TITLE
Feeder: Fix "Notify when offline" not staying switched off

### DIFF
--- a/app/src/main/java/eu/darken/apl/feeder/core/FeederRepo.kt
+++ b/app/src/main/java/eu/darken/apl/feeder/core/FeederRepo.kt
@@ -82,7 +82,7 @@ class FeederRepo @Inject constructor(
                         oldConfigs.remove(existing)
                     }
 
-                    group.copy(configs = oldConfigs + FeederConfig(receiverId = id))
+                    group.copy(configs = oldConfigs + FeederConfig.newFeeder(id))
                 }
             }
         }

--- a/app/src/main/java/eu/darken/apl/feeder/core/config/FeederConfig.kt
+++ b/app/src/main/java/eu/darken/apl/feeder/core/config/FeederConfig.kt
@@ -13,11 +13,18 @@ data class FeederConfig(
     @Contextual @SerialName("addedAt") val addedAt: Instant = Instant.now(),
     @SerialName("label") val label: String? = null,
     @SerialName("position") val position: FeederPosition? = null,
-    @Contextual @SerialName("offlineCheckTimeout") val offlineCheckTimeout: Duration? = DEFAULT_OFFLINE_LIMIT,
+    // Must default to null: the app's Json omits null properties on encode, so a non-null default would
+    // resurrect itself on decode and make disabling offline checks impossible.
+    @Contextual @SerialName("offlineCheckTimeout") val offlineCheckTimeout: Duration? = null,
     @Contextual @SerialName("offlineCheckSnoozedAt") val offlineCheckSnoozedAt: Instant? = null,
     @SerialName("address") val address: String? = null,
 ) {
     companion object {
         val DEFAULT_OFFLINE_LIMIT = Duration.ofHours(48)
+
+        fun newFeeder(receiverId: ReceiverId) = FeederConfig(
+            receiverId = receiverId,
+            offlineCheckTimeout = DEFAULT_OFFLINE_LIMIT,
+        )
     }
 }

--- a/app/src/main/java/eu/darken/apl/feeder/ui/actions/FeederActionSheet.kt
+++ b/app/src/main/java/eu/darken/apl/feeder/ui/actions/FeederActionSheet.kt
@@ -216,11 +216,11 @@ fun FeederActionSheetHost(
                 )
                 Switch(
                     checked = feeder.config.offlineCheckTimeout != null,
-                    onCheckedChange = {
-                        if (Build.VERSION.SDK_INT >= 33) {
+                    onCheckedChange = { checked ->
+                        if (checked && Build.VERSION.SDK_INT >= 33) {
                             notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
                         }
-                        vm.toggleNotifyWhenOffline()
+                        vm.setNotifyWhenOffline(checked)
                     },
                 )
             }

--- a/app/src/main/java/eu/darken/apl/feeder/ui/actions/FeederActionViewModel.kt
+++ b/app/src/main/java/eu/darken/apl/feeder/ui/actions/FeederActionViewModel.kt
@@ -96,14 +96,12 @@ class FeederActionViewModel @Inject constructor(
         feederRepo.removeFeeder(feederId)
     }
 
-    fun toggleNotifyWhenOffline() = launch {
-        log(tag) { "toggleNotifyWhenOffline()" }
-        val newTimeout = if (state.first()?.feeder?.config?.offlineCheckTimeout != null) {
-            null
-        } else {
-            FeederConfig.DEFAULT_OFFLINE_LIMIT
-        }
-        feederRepo.setOfflineCheckTimeout(feederId, newTimeout)
+    fun setNotifyWhenOffline(enabled: Boolean) = launch {
+        log(tag) { "setNotifyWhenOffline($enabled)" }
+        feederRepo.setOfflineCheckTimeout(
+            feederId,
+            if (enabled) FeederConfig.DEFAULT_OFFLINE_LIMIT else null,
+        )
     }
 
     fun renameFeeder(newName: String? = null) = launch {

--- a/app/src/main/java/eu/darken/apl/feeder/ui/preview/FeederMocks.kt
+++ b/app/src/main/java/eu/darken/apl/feeder/ui/preview/FeederMocks.kt
@@ -7,4 +7,4 @@ import eu.darken.apl.feeder.core.config.FeederConfig
 fun mockFeeder(
     label: String = "Home Feeder",
     id: ReceiverId = "abc12",
-) = Feeder(config = FeederConfig(receiverId = id, label = label))
+) = Feeder(config = FeederConfig.newFeeder(id).copy(label = label))

--- a/app/src/test/java/eu/darken/apl/backup/core/BackupDataSerializationTest.kt
+++ b/app/src/test/java/eu/darken/apl/backup/core/BackupDataSerializationTest.kt
@@ -483,6 +483,34 @@ class BackupDataSerializationTest : BaseTest() {
     }
 
     @Test
+    fun `feeder with disabled offline check survives round trip`() {
+        val original = BackupData(
+            version = 1,
+            createdAt = fixedInstant,
+            appVersion = "0.6.1",
+            appVersionCode = 60100,
+            feeders = FeederBackup(
+                configs = listOf(
+                    FeederConfig(
+                        receiverId = "feeder-no-monitoring",
+                        addedAt = fixedInstant,
+                        label = "Silenced",
+                        offlineCheckTimeout = null,
+                    ),
+                ),
+                beastStats = emptyList(),
+                mlatStats = emptyList(),
+            ),
+        )
+
+        val jsonString = json.encodeToString(original)
+        val restored = json.decodeFromString<BackupData>(jsonString)
+
+        restored.feeders!!.configs.single().offlineCheckTimeout shouldBe null
+        restored shouldBe original
+    }
+
+    @Test
     fun `all four watch types serialize with correct type-specific fields`() {
         val backup = BackupData(
             version = 1,

--- a/app/src/test/java/eu/darken/apl/feeder/core/config/FeederConfigTest.kt
+++ b/app/src/test/java/eu/darken/apl/feeder/core/config/FeederConfigTest.kt
@@ -1,19 +1,33 @@
 package eu.darken.apl.feeder.core.config
 
+import eu.darken.apl.common.serialization.SerializationModule
 import eu.darken.apl.feeder.core.ReceiverId
 import io.kotest.matchers.shouldBe
+import kotlinx.serialization.encodeToString
 import org.junit.jupiter.api.Test
 import testhelper.BaseTest
 import java.time.Duration
 
 class FeederConfigTest : BaseTest() {
 
+    private val json = SerializationModule().json()
+
     @Test
-    fun `FeederConfig has offline notifications enabled by default with 48 hour timeout`() {
+    fun `FeederConfig has offline notifications disabled by default`() {
         val receiverId: ReceiverId = "test-receiver-id"
         val config = FeederConfig(receiverId = receiverId)
 
-        config.offlineCheckTimeout shouldBe Duration.ofHours(48)
+        config.offlineCheckTimeout shouldBe null
+    }
+
+    @Test
+    fun `newly added feeders have offline notifications enabled with 48 hour timeout`() {
+        val receiverId: ReceiverId = "test-receiver-id"
+        val config = FeederConfig.newFeeder(receiverId)
+
+        config.receiverId shouldBe receiverId
+        config.offlineCheckTimeout shouldBe FeederConfig.DEFAULT_OFFLINE_LIMIT
+        FeederConfig.DEFAULT_OFFLINE_LIMIT shouldBe Duration.ofHours(48)
     }
 
     @Test
@@ -35,6 +49,45 @@ class FeederConfigTest : BaseTest() {
             receiverId = receiverId,
             offlineCheckTimeout = null
         )
+
+        config.offlineCheckTimeout shouldBe null
+    }
+
+    @Test
+    fun `disabled offline check survives serialization round trip`() {
+        val original = FeederConfig(
+            receiverId = "test-receiver-id",
+            offlineCheckTimeout = null,
+        )
+
+        val restored = json.decodeFromString<FeederConfig>(json.encodeToString(original))
+
+        restored.offlineCheckTimeout shouldBe null
+    }
+
+    @Test
+    fun `enabled offline check survives serialization round trip`() {
+        val original = FeederConfig(
+            receiverId = "test-receiver-id",
+            offlineCheckTimeout = Duration.ofHours(48),
+        )
+
+        val restored = json.decodeFromString<FeederConfig>(json.encodeToString(original))
+
+        restored.offlineCheckTimeout shouldBe Duration.ofHours(48)
+    }
+
+    @Test
+    fun `config without offlineCheckTimeout key decodes as disabled`() {
+        val raw = """
+            {
+                "receiverId": "test-receiver-id",
+                "addedAt": "2026-03-06T12:00:00Z",
+                "label": "Rooftop"
+            }
+        """.trimIndent()
+
+        val config = json.decodeFromString<FeederConfig>(raw)
 
         config.offlineCheckTimeout shouldBe null
     }


### PR DESCRIPTION
The "Notify when offline" switch on a feeder could not be turned off. Tapping it looked like nothing happened — the switch snapped straight back to on, for online and offline feeders alike.

The switch stores "off" as a null timeout. The app's JSON config uses `explicitNulls = false`, so null properties are omitted when writing, and `offlineCheckTimeout` carried a non-null default of 48 hours — a missing key was therefore read back as *enabled*. The off state could never survive a write. The default is now null, and the "enabled for newly added feeders" guarantee moved into an explicit `FeederConfig.newFeeder()` factory that `FeederRepo.addFeeder` uses.

Also fixed: the notification permission was requested on every tap of that switch, including when turning alerts **off**. The switch now passes its target state through to the view model instead of the view model re-deriving it by inverting asynchronously collected state — so the permission is only requested when enabling, and two rapid taps can no longer both act on the same stale value.

### Migration note

A stored feeder config with no `offlineCheckTimeout` key now reads as disabled rather than 48 hours. Every successful stats refresh rewrites the whole feeder group with an explicit value and that path runs at startup, so this only affects installs that have never completed a refresh since the default changed in June 2025, or a raw DataStore restore via device backup. App backups are unaffected — that feature is newer than the regression, so every backup already carries an explicit value.

### Testing

- New round-trip tests built on the real app `Json` instance: a disabled timeout survives encode/decode, an explicit 48h survives, and legacy JSON without the key decodes as disabled.
- New backup round-trip covering a feeder with offline checks disabled — every existing fixture used a non-null timeout, so none of them covered this.
- Full unit suite: 221 tests, no failures.
- Checked on an Android 14 emulator: the switch turns off, stays off after closing and reopening the sheet, and stays off after a force-stop and relaunch; no permission dialog appears when disabling.
